### PR TITLE
Add:UsersTableSeederを作成しシーダを実行

### DIFF
--- a/database/seeds/DatabaseSeeder.php
+++ b/database/seeds/DatabaseSeeder.php
@@ -11,6 +11,6 @@ class DatabaseSeeder extends Seeder
      */
     public function run()
     {
-        // $this->call(UsersTableSeeder::class);
+        $this->call(UsersTableSeeder::class);
     }
 }

--- a/database/seeds/UsersTableSeeder.php
+++ b/database/seeds/UsersTableSeeder.php
@@ -1,0 +1,16 @@
+<?php
+
+use Illuminate\Database\Seeder;
+
+class UsersTableSeeder extends Seeder
+{
+    /**
+     * Run the database seeds.
+     *
+     * @return void
+     */
+    public function run()
+    {
+        //
+    }
+}

--- a/database/seeds/UsersTableSeeder.php
+++ b/database/seeds/UsersTableSeeder.php
@@ -16,14 +16,10 @@ class UsersTableSeeder extends Seeder
                 'name' => 'testuser',
                 'email' => 'testuser@example.com',
                 'password' => Hash::make('testuser0123'),
-                'created_at' => Carbon::now(),
-                'updated_at' => Carbon::now(),
             ],[
                 'name' => 'testuser2',
                 'email' => 'testuser2@example.com',
                 'password' => Hash::make('testuser4567'),
-                'created_at' => Carbon::now(),
-                'updated_at' => Carbon::now(),
             ]
         ]);
     }

--- a/database/seeds/UsersTableSeeder.php
+++ b/database/seeds/UsersTableSeeder.php
@@ -11,6 +11,20 @@ class UsersTableSeeder extends Seeder
      */
     public function run()
     {
-        //
+        DB::table('users')->insert([
+            [
+                'name' => 'testuser',
+                'email' => 'testuser@example.com',
+                'password' => Hash::make('testuser0123'),
+                'created_at' => Carbon::now(),
+                'updated_at' => Carbon::now(),
+            ],[
+                'name' => 'testuser2',
+                'email' => 'testuser2@example.com',
+                'password' => Hash::make('testuser4567'),
+                'created_at' => Carbon::now(),
+                'updated_at' => Carbon::now(),
+            ]
+        ]);
     }
 }


### PR DESCRIPTION
# What
- UsersTableSeederを作成しシーダを実行した。
  - php artisan make:seeder UsersTableSeederを実行
  - UsersTableSeederにダミーデータを記述
  - DatabaseSeeder内でcallメソッドを用いて追加したシーダクラスを呼び出し
  - composer dump-autoloadを実行し、Composerのオートローダを再生成
  - php artisan db:seedでシーダを実行（すでにデータを作成している場合はエラーが出るのでphp artisan migrate:fresh --seedを実行してマイグレーションファイルから作成し直す）
＊composer dump-autoload及びphp artisan db:seedはファイルの変更がないためコミットに反映なし。

# Why
ダミーデータを作成することで今後開発内で行う処理が問題なく実行できるか確認できるようにするため。