### PR TITLE
Make:【サーバーサイド】削除機能

### DIFF
--- a/app/Http/Controllers/PostController.php
+++ b/app/Http/Controllers/PostController.php
@@ -107,5 +107,6 @@ class PostController extends Controller
     public function destroy($id)
     {
         $post = Post::find($id);
+        $post->delete();
     }
 }

--- a/app/Http/Controllers/PostController.php
+++ b/app/Http/Controllers/PostController.php
@@ -106,6 +106,6 @@ class PostController extends Controller
      */
     public function destroy($id)
     {
-        //
+        $post = Post::find($id);
     }
 }

--- a/app/Http/Controllers/PostController.php
+++ b/app/Http/Controllers/PostController.php
@@ -108,5 +108,7 @@ class PostController extends Controller
     {
         $post = Post::find($id);
         $post->delete();
+
+        return redirect('/');
     }
 }

--- a/resources/views/posts/show.blade.php
+++ b/resources/views/posts/show.blade.php
@@ -37,7 +37,7 @@
                           <input class="btn btn-primary" type="submit" value="変更する">
                         </a>
                         <div class="ml-3">
-                          <form method="" action="" id="">
+                          <form method="POST" action="{{ route('posts.destroy', ['id' => $post->id])}}" id="">
                             @csrf
                             <a href="#" class="btn btn-danger" data-id="" onclick="deletePost(this); ">削除する</a>
                           </form>

--- a/resources/views/posts/show.blade.php
+++ b/resources/views/posts/show.blade.php
@@ -37,9 +37,9 @@
                           <input class="btn btn-primary" type="submit" value="変更する">
                         </a>
                         <div class="ml-3">
-                          <form method="POST" action="{{ route('posts.destroy', ['id' => $post->id])}}" id="">
+                          <form method="POST" action="{{ route('posts.destroy', ['id' => $post->id])}}" id="delete_{{ $post->id}}">
                             @csrf
-                            <a href="#" class="btn btn-danger" data-id="" onclick="deletePost(this); ">削除する</a>
+                            <a href="#" class="btn btn-danger" data-id="{{ $post->id }}" onclick="deletePost(this); ">削除する</a>
                           </form>
                         </div>
                       </div>
@@ -50,5 +50,14 @@
         </div>
     </div>
 </div>
+
+<script>
+function deletePost(e) {
+  'use strict';
+  if (confirm('本当に削除してもいいですか？')) {
+    document.getElementById('delete_' + e.dataset.id). submit();
+  }
+}
+</script>
 
 @endsection

--- a/routes/web.php
+++ b/routes/web.php
@@ -27,4 +27,5 @@ Route::group(['prefix' => 'posts', 'middleware' => 'auth'], function(){
     Route::post('store', 'PostController@store')->name('posts.store');
     Route::get('edit/{id}', 'PostController@edit')->name('posts.edit');
     Route::post('update/{id}', 'PostController@update')->name('posts.update');
+    Route::post('destroy/{id}', 'PostController@destroy')->name('posts.destroy');
 });


### PR DESCRIPTION
# What
投稿削除機能を実装する。
- HTMLフォームはmethod要素に、put,patch,deleteをサポートしていないので一先ずdeleteではなくpostで作成した。
- 削除する際、誤った削除を阻止するためにjsでアラートを作成した。

# Why
ユーザーが自由に投稿を削除できるようにするため。