### PR TITLE
add:画像アップロードのバリデーションルールを追加

### DIFF
--- a/app/Http/Requests/StorePost.php
+++ b/app/Http/Requests/StorePost.php
@@ -26,6 +26,7 @@ class StorePost extends FormRequest
         return [
             'title' => 'required|string|max:100',
             'content' => 'required|string|max:1000',
+            'image' => 'required|image|file',
         ];
     }
 }

--- a/resources/lang/ja/validation.php
+++ b/resources/lang/ja/validation.php
@@ -120,6 +120,7 @@ return [
         'password' => 'パスワード',
         'title' => 'タイトル',
         'content' => '内容',
+        'image' => '画像',
     ],
 
 ];


### PR DESCRIPTION
# What
画像アップロードのバリデーションルールを追加した
 - required 必須
 - image 画像ファイルであること
 - file フィールドがアップロードに成功したファイルであること

# Why
画像を投稿フォームにバリデーションが設定されておらずisValidメソッドだけを指定していたのでエラー（Call to a member function isValid() on null）が表示されていた。そのエラー解決するため。