### PR TITLE
add:【サーバーサイド】パスワードの再設定機能

### DIFF
--- a/app/Notifications/ResetPassword.php
+++ b/app/Notifications/ResetPassword.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace App\Notifications;
+
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Notifications\Messages\MailMessage;
+use Illuminate\Notifications\Notification;
+
+class ResetPassword extends Notification
+{
+    use Queueable;
+
+    /**
+     * Create a new notification instance.
+     *
+     * @return void
+     */
+    public function __construct()
+    {
+        //
+    }
+
+    /**
+     * Get the notification's delivery channels.
+     *
+     * @param  mixed  $notifiable
+     * @return array
+     */
+    public function via($notifiable)
+    {
+        return ['mail'];
+    }
+
+    /**
+     * Get the mail representation of the notification.
+     *
+     * @param  mixed  $notifiable
+     * @return \Illuminate\Notifications\Messages\MailMessage
+     */
+    public function toMail($notifiable)
+    {
+        return (new MailMessage)
+                    ->line('The introduction to the notification.')
+                    ->action('Notification Action', url('/'))
+                    ->line('Thank you for using our application!');
+    }
+
+    /**
+     * Get the array representation of the notification.
+     *
+     * @param  mixed  $notifiable
+     * @return array
+     */
+    public function toArray($notifiable)
+    {
+        return [
+            //
+        ];
+    }
+}

--- a/app/Notifications/ResetPassword.php
+++ b/app/Notifications/ResetPassword.php
@@ -49,7 +49,6 @@ class ResetPassword extends Notification
     public function toMail($notifiable)
     {
         return (new MailMessage)
-            ->from('admin@example.com', config('app.name'))
             ->subject('パスワード再設定')
             ->greeting('平素よりイラステをご利用いただきありがとうございます')
             ->line('下のボタンをクリックしてパスワードを再設定してください。')

--- a/app/Notifications/ResetPassword.php
+++ b/app/Notifications/ResetPassword.php
@@ -6,6 +6,7 @@ use Illuminate\Bus\Queueable;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Notifications\Messages\MailMessage;
 use Illuminate\Notifications\Notification;
+use Illuminate\Auth\Notifications\ResetPassword;
 
 class ResetPassword extends Notification
 {

--- a/app/Notifications/ResetPassword.php
+++ b/app/Notifications/ResetPassword.php
@@ -51,7 +51,7 @@ class ResetPassword extends Notification
         return (new MailMessage)
             ->from('admin@example.com', config('app.name'))
             ->subject('パスワード再設定')
-            ->greeting('平素よりアプリをご利用いただきありがとうございます')
+            ->greeting('平素よりイラステをご利用いただきありがとうございます')
             ->line('下のボタンをクリックしてパスワードを再設定してください。')
             ->action(__('パスワードを再設定'), url(config('app.url').route('password.reset', $this->token, false)))
             ->line('もしこのメールに心当たりがない場合は、そのまま削除してください。');

--- a/app/Notifications/ResetPassword.php
+++ b/app/Notifications/ResetPassword.php
@@ -16,7 +16,7 @@ class ResetPassword extends Notification
     * 
     * @var string
     */
-+   public $token;
+    public $token;
 
     /**
      * Create a new notification instance.

--- a/app/Notifications/ResetPassword.php
+++ b/app/Notifications/ResetPassword.php
@@ -12,13 +12,21 @@ class ResetPassword extends Notification
     use Queueable;
 
     /**
+    * The password reset token.
+    * 
+    * @var string
+    */
++   public $token;
+
+    /**
      * Create a new notification instance.
      *
+     * @param string $token
      * @return void
      */
-    public function __construct()
+    public function __construct($token)
     {
-        //
+        $this->token = $token;
     }
 
     /**
@@ -41,9 +49,12 @@ class ResetPassword extends Notification
     public function toMail($notifiable)
     {
         return (new MailMessage)
-                    ->line('The introduction to the notification.')
-                    ->action('Notification Action', url('/'))
-                    ->line('Thank you for using our application!');
+            ->from('admin@example.com', config('app.name'))
+            ->subject('パスワード再設定')
+            ->greeting('平素よりアプリをご利用いただきありがとうございます')
+            ->line('下のボタンをクリックしてパスワードを再設定してください。')
+            ->action(__('パスワードを再設定'), url(config('app.url').route('password.reset', $this->token, false)))
+            ->line('もしこのメールに心当たりがない場合は、そのまま削除してください。');
     }
 
     /**

--- a/app/User.php
+++ b/app/User.php
@@ -5,6 +5,7 @@ namespace App;
 use Illuminate\Contracts\Auth\MustVerifyEmail;
 use Illuminate\Foundation\Auth\User as Authenticatable;
 use Illuminate\Notifications\Notifiable;
+use App\Notifications\ResetPassword;
 
 class User extends Authenticatable
 {
@@ -40,5 +41,16 @@ class User extends Authenticatable
     public function post()
     {
         return $this->hasMany('App\Models\Post');
+    }
+
+    /**
+     * パスワードリセット通知の送信
+     *
+     * @param  string  $token
+     * @return void
+     */
+    public function sendPasswordResetNotification($token)
+    {
+        $this->notify(new ResetPassword($token));
     }
 }

--- a/resources/views/auth/passwords/reset.blade.php
+++ b/resources/views/auth/passwords/reset.blade.php
@@ -5,7 +5,7 @@
     <div class="row justify-content-center">
         <div class="col-md-8">
             <div class="card">
-                <div class="card-header　text-center font-weight-bold">{{ __('パスワードをリセットする') }}</div>
+                <div class="card-header text-center font-weight-bold">{{ __('パスワードをリセットする') }}</div>
 
                 <div class="card-body">
                     <form method="POST" action="{{ route('password.update') }}">


### PR DESCRIPTION
# What
パスワードの再設定機能を追加する。今回はgoogleのsmtpサーバーを用いて再設定メールを送信できるようにする。
- .envで必要な環境変数を設定する(MAIL関係の変数だけでなく、メール内のリンク設定で用いるAPP_URLにも留意する) 
- app/Notifications/ResetPassword.phpを作成
- トークンの宣言
- メールのテンプレートを設定
- app/User.phpで必要なメソッドを定義

# Why
ユーザーがパスワードを失念した時にメールアドレスがあれば再びパスワードを設定できるようにするため。
