### PR TITLE
modified:ResetPassword.php及びResetPasswordクラスの名称を変更

### DIFF
--- a/app/Notifications/UserResetPassword.php
+++ b/app/Notifications/UserResetPassword.php
@@ -8,7 +8,7 @@ use Illuminate\Notifications\Messages\MailMessage;
 use Illuminate\Notifications\Notification;
 use Illuminate\Auth\Notifications\ResetPassword;
 
-class ResetPassword extends Notification
+class UserResetPassword extends Notification
 {
     use Queueable;
 

--- a/app/User.php
+++ b/app/User.php
@@ -5,7 +5,7 @@ namespace App;
 use Illuminate\Contracts\Auth\MustVerifyEmail;
 use Illuminate\Foundation\Auth\User as Authenticatable;
 use Illuminate\Notifications\Notifiable;
-use App\Notifications\ResetPassword;
+use App\Notifications\UserResetPassword;
 
 class User extends Authenticatable
 {
@@ -51,6 +51,6 @@ class User extends Authenticatable
      */
     public function sendPasswordResetNotification($token)
     {
-        $this->notify(new ResetPassword($token));
+        $this->notify(new UserResetPassword($token));
     }
 }


### PR DESCRIPTION
# What
パスワード再設定メールを送信すると以下のエラーが発生する。
Cannot declare class App\Notifications\ResetPassword because the name is already in use
そのため、Illuminate内のクラスと名前が被らないようにResetPassword.php及びResetPasswordクラスの名称をUserResetPassword.php及びUserResetPasswordクラスに変更した。

# Why
ユーザーパスワードリセット機能を正常に機能させるため。