### PR TITLE
modified:編集ページに画像ファイルフォームを追加及びデザイン変更

### DIFF
--- a/app/Http/Controllers/PostController.php
+++ b/app/Http/Controllers/PostController.php
@@ -111,6 +111,14 @@ class PostController extends Controller
     {
         $post = Post::find($id);
 
+        $uploadImg = $request->file('image');
+        if ($uploadImg->isValid()) {
+        $path = Storage::disk('s3')->putFile('/', $uploadImg, 'public');
+        $post->image = Storage::disk('s3')->url($path);
+        } else {
+            $post->image = "";
+        }
+
         $post->title = $request->input('title');
         $post->content = $request->input('content');
         $post->user_id = Auth::user()->id;

--- a/public/css/app.css
+++ b/public/css/app.css
@@ -10944,12 +10944,17 @@ a.text-dark:focus {
   }
 }
 
-.form-design label {
+.form-design__label {
   padding: 5px 20px;
   color: #ffffff;
   background-color: #295d72;
   cursor: pointer;
   border-radius: 10px;
+  transition: 0.3s;
+}
+
+.form-design__label:hover {
+  opacity: 0.8;
 }
 
 .form-design input[type=file] {

--- a/public/css/app.css
+++ b/public/css/app.css
@@ -1,5 +1,4 @@
-@charset "UTF-8";
-@import url(https://fonts.googleapis.com/css?family=Nunito);
+@import url(https://fonts.googleapis.com/css?family=Nunito);@charset "UTF-8";
 
 /*!
  * Bootstrap v4.6.0 (https://getbootstrap.com/)
@@ -10943,5 +10942,17 @@ a.text-dark:focus {
     color: inherit;
     border-color: #dee2e6;
   }
+}
+
+.form-design label {
+  padding: 5px 20px;
+  color: #ffffff;
+  background-color: #295d72;
+  cursor: pointer;
+  border-radius: 10px;
+}
+
+.form-design input[type=file] {
+  display: none;
 }
 

--- a/public/js/app.js
+++ b/public/js/app.js
@@ -37338,6 +37338,20 @@ __webpack_require__(/*! ./bootstrap */ "./resources/js/bootstrap.js");
 
 /***/ }),
 
+/***/ "./resources/js/assets/input_file.js":
+/*!*******************************************!*\
+  !*** ./resources/js/assets/input_file.js ***!
+  \*******************************************/
+/*! no static exports found */
+/***/ (function(module, exports) {
+
+$('input').on('change', function () {
+  var file = $(this).prop('files')[0];
+  $('span').text(file.name);
+});
+
+/***/ }),
+
 /***/ "./resources/js/bootstrap.js":
 /*!***********************************!*\
   !*** ./resources/js/bootstrap.js ***!
@@ -37395,13 +37409,14 @@ window.axios.defaults.headers.common['X-Requested-With'] = 'XMLHttpRequest';
 /***/ }),
 
 /***/ 0:
-/*!*************************************************************!*\
-  !*** multi ./resources/js/app.js ./resources/sass/app.scss ***!
-  \*************************************************************/
+/*!*************************************************************************************************!*\
+  !*** multi ./resources/js/app.js ./resources/js/assets/input_file.js ./resources/sass/app.scss ***!
+  \*************************************************************************************************/
 /*! no static exports found */
 /***/ (function(module, exports, __webpack_require__) {
 
 __webpack_require__(/*! /Applications/MAMP/htdocs/illust_station/resources/js/app.js */"./resources/js/app.js");
+__webpack_require__(/*! /Applications/MAMP/htdocs/illust_station/resources/js/assets/input_file.js */"./resources/js/assets/input_file.js");
 module.exports = __webpack_require__(/*! /Applications/MAMP/htdocs/illust_station/resources/sass/app.scss */"./resources/sass/app.scss");
 
 

--- a/public/js/app.js
+++ b/public/js/app.js
@@ -37347,7 +37347,7 @@ __webpack_require__(/*! ./bootstrap */ "./resources/js/bootstrap.js");
 
 $('input').on('change', function () {
   var file = $(this).prop('files')[0];
-  $('span').text(file.name);
+  $('.select-image').text(file.name);
 });
 
 /***/ }),

--- a/resources/js/assets/input_file.js
+++ b/resources/js/assets/input_file.js
@@ -1,0 +1,4 @@
+$('input').on('change', function () {
+  var file = $(this).prop('files')[0];
+  $('span').text(file.name);
+});

--- a/resources/js/assets/input_file.js
+++ b/resources/js/assets/input_file.js
@@ -1,4 +1,4 @@
 $('input').on('change', function () {
   var file = $(this).prop('files')[0];
-  $('span').text(file.name);
+  $('.select-image').text(file.name);
 });

--- a/resources/sass/app.scss
+++ b/resources/sass/app.scss
@@ -6,3 +6,5 @@
 
 // Bootstrap
 @import '~bootstrap/scss/bootstrap';
+
+@import 'posts/input_type_image.scss';

--- a/resources/sass/posts/input_type_image.scss
+++ b/resources/sass/posts/input_type_image.scss
@@ -1,0 +1,12 @@
+.form-design {
+  label {
+    padding: 5px 20px;
+    color: #ffffff;
+    background-color: #295d72;
+    cursor: pointer;
+    border-radius:10px;
+  }
+  input[type="file"] {
+    display: none;
+  }
+}

--- a/resources/sass/posts/input_type_image.scss
+++ b/resources/sass/posts/input_type_image.scss
@@ -1,10 +1,14 @@
 .form-design {
-  label {
+  &__label {
     padding: 5px 20px;
     color: #ffffff;
     background-color: #295d72;
     cursor: pointer;
     border-radius:10px;
+    transition: .3s;
+    &:hover {
+      opacity: 0.8;
+    }
   }
   input[type="file"] {
     display: none;

--- a/resources/views/posts/create.blade.php
+++ b/resources/views/posts/create.blade.php
@@ -38,7 +38,7 @@
                       <div class="form-design">
                           <label for="form-image" class="form-design__label">ファイルを選択</label>
                           <input type="file" name="image" id="form-image">
-                          <span>選択されていません</span>
+                          <span class="select-image">選択されていません</span>
                       </div>
                       <input class="btn font-weight-bold mt-2" style="color: #f8f9fa; background-color: #295d72;" type="submit" value="投稿する">
                     </form>

--- a/resources/views/posts/create.blade.php
+++ b/resources/views/posts/create.blade.php
@@ -35,8 +35,11 @@
                       <br>
                       <textarea name="content" id="content" cols="50" rows="5"></textarea>
                       <br>
-                      <input type="file" name="image">
-                      <br>
+                      <div class="form-design">
+                          <label for="form-image" class="form-design__label">ファイルを選択</label>
+                          <input type="file" name="image" id="form-image">
+                          <span>選択されていません</span>
+                      </div>
                       <input class="btn font-weight-bold mt-2" style="color: #f8f9fa; background-color: #295d72;" type="submit" value="投稿する">
                     </form>
                 </div>

--- a/resources/views/posts/edit.blade.php
+++ b/resources/views/posts/edit.blade.php
@@ -36,7 +36,7 @@
                     <textarea name="content" id="content" cols="50" rows="5">{{$post->content}}</textarea>
                     <br>
                     <div class="form-design">
-                        <label for="form-image">ファイルを選択</label>
+                        <label for="form-image" class="form-design__label">ファイルを選択</label>
                         <input type="file" name="image" id="form-image">
                         <span>選択されていません</span>
                     </div>

--- a/resources/views/posts/edit.blade.php
+++ b/resources/views/posts/edit.blade.php
@@ -24,7 +24,7 @@
                     </div>
                     @endif
 
-                    <form method="POST" action="{{ route('posts.update', ['id' => $post->id ])}}">
+                    <form method="POST" action="{{ route('posts.update', ['id' => $post->id ])}}" enctype="multipart/form-data">
                     @csrf
 
                     <label for="title">タイトル</label>
@@ -38,7 +38,7 @@
                     <div class="form-design">
                         <label for="form-image" class="form-design__label">ファイルを選択</label>
                         <input type="file" name="image" id="form-image">
-                        <span>選択されていません</span>
+                        <span class="select-image">選択されていません</span>
                     </div>
                     <input class="btn btn-primary mt-2" type="submit" value="登録する">
                     

--- a/resources/views/posts/edit.blade.php
+++ b/resources/views/posts/edit.blade.php
@@ -35,9 +35,12 @@
                     <br>
                     <textarea name="content" id="content" cols="50" rows="5">{{$post->content}}</textarea>
                     <br>
-                    <input type="file" name="image">
-                    <br>
-                    <input class="btn btn-primary" type="submit" value="登録する">
+                    <div class="form-design">
+                        <label for="form-image">ファイルを選択</label>
+                        <input type="file" name="image" id="form-image">
+                        <span>選択されていません</span>
+                    </div>
+                    <input class="btn btn-primary mt-2" type="submit" value="登録する">
                     
                     </form>
                 </div>

--- a/resources/views/posts/edit.blade.php
+++ b/resources/views/posts/edit.blade.php
@@ -35,6 +35,8 @@
                     <br>
                     <textarea name="content" id="content" cols="50" rows="5">{{$post->content}}</textarea>
                     <br>
+                    <input type="file" name="image">
+                    <br>
                     <input class="btn btn-primary" type="submit" value="登録する">
                     
                     </form>

--- a/webpack.mix.js
+++ b/webpack.mix.js
@@ -11,5 +11,11 @@ const mix = require('laravel-mix');
  |
  */
 
-mix.js('resources/js/app.js', 'public/js')
-    .sass('resources/sass/app.scss', 'public/css');
+// mix.js('resources/js/app.js', 'public/js')
+//     .sass('resources/sass/app.scss', 'public/css');
+
+mix.js([
+    'resources/js/app.js',
+    'resources/js/assets/input_file.js',
+    ], 'public/js/app.js')
+   .sass('resources/sass/app.scss', 'public/css');


### PR DESCRIPTION
# What
resources/posts/edit.blade.phpに画像ファイルフォームを作成する。
- <input type="file">を用いてフォームを作成
- enctype="multipart/form-data"を指定。multipart/form-data形式でサーバーにデータを送信する。
- postコントローラーでupdateアクションにstoreアクションと同じ処理を記述

画像ファイルフォームのデザインを変更
- labelタグを用いてinputタグのデザインを修正
- inputタグに選択した画像ファイル名はjQueryを用いて隣に表示した。

投稿ページのデザインもサイトの統一性を出すために修正

# Why
- 投稿を編集画面で画像ファイルの編集をできるようにするため
- 画像ファイルフォームのデフォルトデザインだとサイト全体のデザインと比較して違和感があるため