### PR TITLE
add:【サーバーサイド】コメント機能

### DIFF
--- a/app/Http/Controllers/CommentController.php
+++ b/app/Http/Controllers/CommentController.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use Illuminate\Http\Request;
+
+class CommentController extends Controller
+{
+    //
+}

--- a/app/Http/Controllers/CommentController.php
+++ b/app/Http/Controllers/CommentController.php
@@ -3,8 +3,22 @@
 namespace App\Http\Controllers;
 
 use Illuminate\Http\Request;
+use App\Models\Comment;
+use App\Models\Post;
+use Illuminate\Support\Facades\Auth;
 
 class CommentController extends Controller
 {
-    //
+    public function store(Request $request)
+    {
+        $user = Auth::user();
+        $post_id = $request->input('post_id');
+        $comment = $request->input('comment');
+        Comment::create([
+            'user_id' => $user->id,
+            'post_id' => $post_id,
+            'comment' => $comment
+        ]);
+        return redirect()->route('posts.show', ['id' => $post_id ]);
+    }
 }

--- a/app/Models/Comment.php
+++ b/app/Models/Comment.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+class Comment extends Model
+{
+    //
+}

--- a/app/Models/Comment.php
+++ b/app/Models/Comment.php
@@ -6,5 +6,15 @@ use Illuminate\Database\Eloquent\Model;
 
 class Comment extends Model
 {
-    //
+    protected $fillable = ['user_id', 'post_id', 'comment'];
+
+    public function user()
+    {
+        return $this->belongsTo('App\User');
+    }
+
+    public function post()
+    {
+        return $this->belongsTo('App\Models/Post');
+    }
 }

--- a/app/Models/Post.php
+++ b/app/Models/Post.php
@@ -12,4 +12,9 @@ class Post extends Model
     {
         return $this->belongsTo('App\User');
     }
+
+    public function comment()
+    {
+        return $this->hasMany('App\Models\Comment');
+    }
 }

--- a/app/User.php
+++ b/app/User.php
@@ -43,6 +43,11 @@ class User extends Authenticatable
         return $this->hasMany('App\Models\Post');
     }
 
+    public function comment()
+    {
+        return $this->hasMany('App\Models\Comment');
+    }
+
     /**
      * パスワードリセット通知の送信
      *

--- a/database/migrations/2021_05_29_113403_create_comments_table.php
+++ b/database/migrations/2021_05_29_113403_create_comments_table.php
@@ -1,0 +1,36 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class CreateCommentsTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('comments', function (Blueprint $table) {
+            $table->bigIncrements('id');
+            $table->bigInteger('user_id')->unsigned();
+            $table->bigInteger('post_id')->unsigned();
+            $table->string('comment');
+            $table->timestamps();
+            $table->foreign('user_id')->references('id')->on('users')->onDelete('cascade');
+            $table->foreign('post_id')->references('id')->on('posts')->onDelete('cascade');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('comments');
+    }
+}

--- a/public/css/app.css
+++ b/public/css/app.css
@@ -10972,3 +10972,8 @@ a.text-dark:focus {
   color: #f8f9fa;
 }
 
+.comment__button {
+  display: block;
+  margin: 10px 0 0 auto;
+}
+

--- a/public/css/app.css
+++ b/public/css/app.css
@@ -10977,3 +10977,23 @@ a.text-dark:focus {
   margin: 10px 0 0 auto;
 }
 
+.comment__body {
+  padding: 5px 30px 20px 30px;
+}
+
+.comment__body:hover {
+  background-color: #dfdfdf;
+}
+
+.comment__body-user {
+  font-weight: bold;
+  font-size: 20px;
+}
+
+.comment__body-time {
+  font-size: 10px;
+  margin-top: 10px;
+  margin-left: 5px;
+  color: #a0a0a0;
+}
+

--- a/resources/sass/app.scss
+++ b/resources/sass/app.scss
@@ -9,4 +9,6 @@
 
 @import 'posts/input_type_image.scss';
 
-@import 'button'
+@import 'button';
+
+@import 'posts/comment';

--- a/resources/sass/posts/comment.scss
+++ b/resources/sass/posts/comment.scss
@@ -12,4 +12,20 @@
     display: block;
     margin: 10px 0 0 auto;
   }
+  &__body {
+    padding: 5px 30px 20px 30px;
+    &:hover {
+      background-color: #dfdfdf;
+    }
+  }
+  &__body-user {
+    font-weight: bold;
+    font-size: 20px;
+  }
+  &__body-time {
+    font-size: 10px;
+    margin-top: 10px;
+    margin-left: 5px;
+    color: #a0a0a0;
+  }
 }

--- a/resources/sass/posts/comment.scss
+++ b/resources/sass/posts/comment.scss
@@ -1,0 +1,15 @@
+.comment {
+  &__area {
+
+  }
+  &__submit-area {
+
+  }
+  &__textarea {
+
+  }
+  &__button {
+    display: block;
+    margin: 10px 0 0 auto;
+  }
+}

--- a/resources/views/comments/comment.blade.php
+++ b/resources/views/comments/comment.blade.php
@@ -1,0 +1,13 @@
+<div class="media">
+    <div class="media-body comment-body">
+        <div class="row">
+            <span class="comment-body-user">TestName</span>
+            <span class="comment-body-time">2020-01-06 12:16:45</span>
+        </div>
+        <span class="comment-body-content">
+            Cras sit amet nibh libero, in gravida nulla. Nulla vel metus scelerisque ante sollicitudin. Cras purus odio,
+            vestibulum in vulputate at, tempus viverra turpis. Fusce condimentum nunc ac nisi vulputate fringilla. Donec
+            lacinia congue felis in faucibus.
+        </span>
+    </div>
+</div>

--- a/resources/views/comments/comment.blade.php
+++ b/resources/views/comments/comment.blade.php
@@ -5,7 +5,7 @@
             <span class="comment__body-time">{{ $comment->created_at }}</span>
         </div>
         <span class="comment__body-content">
-            {{ $comment->comment }}
+            {!! nl2br(e($comment->comment)) !!}
         </span>
     </div>
 </div>

--- a/resources/views/comments/comment.blade.php
+++ b/resources/views/comments/comment.blade.php
@@ -1,13 +1,11 @@
 <div class="comment__media">
     <div class="comment__media-body comment__body">
         <div class="row">
-            <span class="comment__body-user">TestName</span>
-            <span class="comment__body-time">2020-01-06 12:16:45</span>
+            <span class="comment__body-user">{{ $comment->user->name }}</span>
+            <span class="comment__body-time">{{ $comment->created_at }}</span>
         </div>
         <span class="comment__body-content">
-            Cras sit amet nibh libero, in gravida nulla. Nulla vel metus scelerisque ante sollicitudin. Cras purus odio,
-            vestibulum in vulputate at, tempus viverra turpis. Fusce condimentum nunc ac nisi vulputate fringilla. Donec
-            lacinia congue felis in faucibus.
+            {{ $comment->comment }}
         </span>
     </div>
 </div>

--- a/resources/views/comments/comment.blade.php
+++ b/resources/views/comments/comment.blade.php
@@ -1,10 +1,10 @@
-<div class="media">
-    <div class="media-body comment-body">
+<div class="comment__media">
+    <div class="comment__media-body comment__body">
         <div class="row">
-            <span class="comment-body-user">TestName</span>
-            <span class="comment-body-time">2020-01-06 12:16:45</span>
+            <span class="comment__body-user">TestName</span>
+            <span class="comment__body-time">2020-01-06 12:16:45</span>
         </div>
-        <span class="comment-body-content">
+        <span class="comment__body-content">
             Cras sit amet nibh libero, in gravida nulla. Nulla vel metus scelerisque ante sollicitudin. Cras purus odio,
             vestibulum in vulputate at, tempus viverra turpis. Fusce condimentum nunc ac nisi vulputate fringilla. Donec
             lacinia congue felis in faucibus.

--- a/resources/views/posts/show.blade.php
+++ b/resources/views/posts/show.blade.php
@@ -35,19 +35,19 @@
                     {{-- 現在ログインしているユーザーの投稿であれば表示する --}}
 
                     @auth
-                    　@if(($post->user_id) === (Auth::user()->id ))
-                      <div class="d-flex">
-                        <a href="{{ route('posts.edit', ['id' => $post->id])}}">
-                          <input class="btn btn-primary" type="submit" value="変更する">
-                        </a>
-                        <div class="ml-3">
-                          <form method="POST" action="{{ route('posts.destroy', ['id' => $post->id])}}" id="delete_{{ $post->id}}">
-                            @csrf
-                            <a href="#" class="btn btn-outline-danger" data-id="{{ $post->id }}" onclick="deletePost(this); ">削除する</a>
-                          </form>
-                        </div>
-                      </div>
-                      @endif
+                        @if(($post->user_id) === (Auth::user()->id ))
+                            <div class="d-flex">
+                                <a href="{{ route('posts.edit', ['id' => $post->id])}}">
+                                    <input class="btn btn-primary" type="submit" value="変更する">
+                                </a>
+                                <div class="ml-3">
+                                    <form method="POST" action="{{ route('posts.destroy', ['id' => $post->id])}}" id="delete_{{ $post->id}}">
+                                        @csrf
+                                        <a href="#" class="btn btn-outline-danger" data-id="{{ $post->id }}" onclick="deletePost(this); ">削除する</a>
+                                    </form>
+                                </div>
+                            </div>
+                        @endif
                     @endauth
                 </div>
             </div>

--- a/resources/views/posts/show.blade.php
+++ b/resources/views/posts/show.blade.php
@@ -48,6 +48,18 @@
                                 </div>
                             </div>
                         @endif
+                        <div class="comment row justify-content-center mt-3">
+                            <div class="comment__area">
+                                <div class="font-weight-bold">
+                                    この投稿へのコメント
+                                </div>
+                                </div>
+                            </div>
+                            <div class="comment__submit-area mt-3">
+                                <textarea class="form-control comment__textarea" placeholder="テキストを入力" aria-label="With textarea"></textarea>
+                                <button type="input-group-prepend button" class="btn btn-outline-primary comment__button">コメントする</button>
+                            </div>
+                        </div>
                     @endauth
                 </div>
             </div>

--- a/resources/views/posts/show.blade.php
+++ b/resources/views/posts/show.blade.php
@@ -53,6 +53,7 @@
                                 <div class="font-weight-bold text-center">
                                     この投稿へのコメント
                                 </div>
+                                @include('comments.comment')
                             </div>
                             <div class="comment__submit-area mt-3">
                                 <textarea class="form-control comment__textarea" placeholder="テキストを入力" aria-label="With textarea"></textarea>

--- a/resources/views/posts/show.blade.php
+++ b/resources/views/posts/show.blade.php
@@ -55,10 +55,14 @@
                                 </div>
                                 @include('comments.comment')
                             </div>
-                            <div class="comment__submit-area mt-3">
-                                <textarea class="form-control comment__textarea" placeholder="テキストを入力" aria-label="With textarea"></textarea>
-                                <button type="input-group-prepend button" class="btn btn-outline-primary comment__button">コメントする</button>
-                            </div>
+                            <form method="POST" action="{{route('comments.store')}}">
+                                @csrf
+                                <input type="hidden" name="post_id"  value="{{ $post->id }}">
+                                <div class="comment__submit-area mt-3">
+                                    <textarea id="comment" name="comment" class="form-control comment__textarea" placeholder="テキストを入力" aria-label="With textarea"></textarea>
+                                    <button type="input-group-prepend button submit" class="btn btn-outline-primary comment__button">コメントする</button>
+                                </div>
+                            </form>
                         </div>
                     @endauth
                 </div>

--- a/resources/views/posts/show.blade.php
+++ b/resources/views/posts/show.blade.php
@@ -53,7 +53,9 @@
                                 <div class="font-weight-bold text-center">
                                     この投稿へのコメント
                                 </div>
-                                @include('comments.comment')
+                                @foreach ($post->comment as $comment)
+                                    @include('comments.comment')
+                                @endforeach
                             </div>
                             <form method="POST" action="{{route('comments.store')}}">
                                 @csrf

--- a/resources/views/posts/show.blade.php
+++ b/resources/views/posts/show.blade.php
@@ -48,11 +48,10 @@
                                 </div>
                             </div>
                         @endif
-                        <div class="comment row justify-content-center mt-3">
+                        <div class="comment justify-content-center mt-3">
                             <div class="comment__area">
-                                <div class="font-weight-bold">
+                                <div class="font-weight-bold text-center">
                                     この投稿へのコメント
-                                </div>
                                 </div>
                             </div>
                             <div class="comment__submit-area mt-3">

--- a/resources/views/posts/show.blade.php
+++ b/resources/views/posts/show.blade.php
@@ -36,7 +36,7 @@
 
                     @auth
                         @if(($post->user_id) === (Auth::user()->id ))
-                            <div class="d-flex">
+                            <div class="d-flex mt-3">
                                 <a href="{{ route('posts.edit', ['id' => $post->id])}}">
                                     <input class="btn btn-primary" type="submit" value="変更する">
                                 </a>

--- a/routes/web.php
+++ b/routes/web.php
@@ -15,9 +15,9 @@
 //     return view('welcome');
 // });
 
-Auth::routes();
+// Route::get('/home', 'HomeController@index')->name('home');
 
-Route::get('/home', 'HomeController@index')->name('home');
+Auth::routes();
 
 Route::get('/', 'PostController@index')->name('posts.index');
 Route::get('posts/show/{id}', 'PostController@show')->name('posts.show');

--- a/routes/web.php
+++ b/routes/web.php
@@ -36,4 +36,5 @@ Route::group(['middleware' => 'auth'], function()
   Route::get('edit/{id}', 'UserController@edit')->name('users.edit');
   Route::post('update/{id}', 'UserController@update')->name('users.update');
   Route::post('destroy/{id}', 'UserController@destroy')->name('users.destroy');
+  Route::post('store', 'CommentController@store')->name('comments.store');
 });

--- a/routes/web.php
+++ b/routes/web.php
@@ -30,11 +30,10 @@ Route::group(['prefix' => 'posts', 'middleware' => 'auth'], function(){
     Route::post('destroy/{id}', 'PostController@destroy')->name('posts.destroy');
 });
 
-Route::group(['middleware' => 'auth'], function()
-{  
-  Route::get('show/{id}', 'UserController@show')->name('users.show');
-  Route::get('edit/{id}', 'UserController@edit')->name('users.edit');
-  Route::post('update/{id}', 'UserController@update')->name('users.update');
-  Route::post('destroy/{id}', 'UserController@destroy')->name('users.destroy');
-  Route::post('store', 'CommentController@store')->name('comments.store');
+Route::group(['middleware' => 'auth'], function(){  
+    Route::get('show/{id}', 'UserController@show')->name('users.show');
+    Route::get('edit/{id}', 'UserController@edit')->name('users.edit');
+    Route::post('update/{id}', 'UserController@update')->name('users.update');
+    Route::post('destroy/{id}', 'UserController@destroy')->name('users.destroy');
+    Route::post('store', 'CommentController@store')->name('comments.store');
 });


### PR DESCRIPTION
# What
投稿にコメントできる機能を実装する
- show.blade.phpにコメントフォーム及びコメント表示要素をマークアップ
- commentテーブル及びcommentモデルを作成した
- commentテーブルはuserテーブル及びpostテーブルそれぞれに対して１対多の関係にあるのでそれぞれのモデルにリレーションを記述
- ルーティングを記述しcommentコントローラにstoreアクションを追加した
- フォームからコメントする投稿の情報を取得するためにhiddenタイプのinputタグを設置し、表示している投稿のpost_idを設定し送信できるようにした
- 情報を受け取り、DBに保存、viewに表示できるようにstoreアクションの処理を記述した
- foreachを用いてviewに表示した

# Why
投稿にコメントをつけれるようにすることでユーザー同士の交流が活発になるため。