### PR TITLE
Add:【サーバーサイド】コメントFormにバリデーションを追加

### DIFF
--- a/app/Http/Controllers/CommentController.php
+++ b/app/Http/Controllers/CommentController.php
@@ -10,7 +10,7 @@ use App\Http\Requests\CommentStore;
 
 class CommentController extends Controller
 {
-    public function store(Request $request)
+    public function store(CommentStore $request)
     {
         $user = Auth::user();
         $post_id = $request->input('post_id');

--- a/app/Http/Controllers/CommentController.php
+++ b/app/Http/Controllers/CommentController.php
@@ -6,6 +6,7 @@ use Illuminate\Http\Request;
 use App\Models\Comment;
 use App\Models\Post;
 use Illuminate\Support\Facades\Auth;
+use App\Http\Requests\CommentStore;
 
 class CommentController extends Controller
 {

--- a/app/Http/Requests/CommentStore.php
+++ b/app/Http/Requests/CommentStore.php
@@ -13,7 +13,7 @@ class CommentStore extends FormRequest
      */
     public function authorize()
     {
-        return false;
+        return true;
     }
 
     /**

--- a/app/Http/Requests/CommentStore.php
+++ b/app/Http/Requests/CommentStore.php
@@ -24,7 +24,7 @@ class CommentStore extends FormRequest
     public function rules()
     {
         return [
-            //
+            'comment' => 'required|string',
         ];
     }
 }

--- a/app/Http/Requests/CommentStore.php
+++ b/app/Http/Requests/CommentStore.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class CommentStore extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     *
+     * @return bool
+     */
+    public function authorize()
+    {
+        return false;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array
+     */
+    public function rules()
+    {
+        return [
+            //
+        ];
+    }
+}

--- a/resources/lang/ja/validation.php
+++ b/resources/lang/ja/validation.php
@@ -121,6 +121,7 @@ return [
         'title' => 'タイトル',
         'content' => '内容',
         'image' => '画像',
+        'comment' => 'コメント',
     ],
 
 ];

--- a/resources/views/posts/show.blade.php
+++ b/resources/views/posts/show.blade.php
@@ -57,6 +57,15 @@
                                     @include('comments.comment')
                                 @endforeach
                             </div>
+                            @if ($errors->any())
+                                <div class="alert alert-danger">
+                                    <ul>
+                                        @foreach ($errors->all() as $error)
+                                            <li>{{ $error }}</li>
+                                        @endforeach
+                                    </ul>
+                                </div>
+                            @endif
                             <form method="POST" action="{{route('comments.store')}}">
                                 @csrf
                                 <input type="hidden" name="post_id"  value="{{ $post->id }}">

--- a/resources/views/posts/show.blade.php
+++ b/resources/views/posts/show.blade.php
@@ -58,8 +58,8 @@
                                 @endforeach
                             </div>
                             @if ($errors->any())
-                                <div class="alert alert-danger">
-                                    <ul>
+                                <div class="alert alert-danger mt-3">
+                                    <ul class="mb-0">
                                         @foreach ($errors->all() as $error)
                                             <li>{{ $error }}</li>
                                         @endforeach


### PR DESCRIPTION
# What
コメントフォームにバリデーションが効くように設定した。
- フォームリクエストクラスを用いて投稿へのコメントをする際にバリデーションが効くようにする
- commentカラムに対してrequired（必須）、string（文字列）でないとコメントが弾かれるようにした。

# Why
不適切な情報のデータを保存できないようにするため。