### PR TITLE
Edit:【マークアップ】認証関係のページのデザインを修正

### DIFF
--- a/app/Http/Controllers/Auth/ResetPasswordController.php
+++ b/app/Http/Controllers/Auth/ResetPasswordController.php
@@ -25,7 +25,7 @@ class ResetPasswordController extends Controller
      *
      * @var string
      */
-    protected $redirectTo = '/home';
+    protected $redirectTo = '/';
 
     /**
      * Create a new controller instance.

--- a/public/css/app.css
+++ b/public/css/app.css
@@ -11019,6 +11019,14 @@ a.text-dark:focus {
   font-weight: 700;
 }
 
+.auth-form__title {
+  margin-top: -8px;
+  margin-bottom: 30px;
+  color: #757c80;
+  font-size: 20px;
+  font-weight: 700;
+}
+
 .auth-form__form-box {
   margin: 0 15px;
 }
@@ -11048,6 +11056,7 @@ a.text-dark:focus {
 .auth-form__social {
   border-bottom: 1px solid rgba(0, 0, 0, 0.08);
   padding-bottom: 16px;
+  margin-top: 16px;
 }
 
 .auth-form__social-link:hover {

--- a/public/css/app.css
+++ b/public/css/app.css
@@ -11027,6 +11027,13 @@ a.text-dark:focus {
   font-weight: 700;
 }
 
+.auth-form__discription {
+  margin-top: -16px;
+  color: #757c80;
+  font-size: 10px;
+  font-weight: 700;
+}
+
 .auth-form__form-box {
   margin: 0 15px;
 }
@@ -11079,7 +11086,7 @@ a.text-dark:focus {
 
 .auth-button {
   display: block;
-  margin: 10px auto 5px;
+  margin: 14px auto 5px;
   height: 40px;
   border-radius: 22px;
   border-style: none;

--- a/public/css/app.css
+++ b/public/css/app.css
@@ -10997,7 +10997,7 @@ a.text-dark:focus {
   color: #a0a0a0;
 }
 
-.login-form {
+.auth-form {
   margin-top: 50px;
   padding: 40px 0 38px;
   background-color: rgba(255, 255, 255, 0.92);
@@ -11005,56 +11005,56 @@ a.text-dark:focus {
   text-align: center;
 }
 
-.login-form__logo-box {
+.auth-form__logo-box {
   margin-bottom: 32px;
 }
 
-.login-form__logo {
+.auth-form__logo {
   margin-bottom: 6px;
 }
 
-.login-form__catchphrase {
+.auth-form__catchphrase {
   color: #757c80;
   font-size: 12px;
   font-weight: 700;
 }
 
-.login-form__form-box {
+.auth-form__form-box {
   margin: 0 15px;
 }
 
-.login-form__field {
+.auth-form__field {
   border-radius: 4px 4px 0 0;
 }
 
-.login-form__input {
+.auth-form__input {
   color: #757c80;
 }
 
-.login-form__reset-box {
+.auth-form__reset-box {
   display: block;
   margin: 0 auto;
   width: 100%;
   box-sizing: border-box;
 }
 
-.login-form__reset-link {
+.auth-form__reset-link {
   display: block;
   margin-left: auto;
   text-align: right;
   font-size: 12px;
 }
 
-.login-form__social {
+.auth-form__social {
   border-bottom: 1px solid rgba(0, 0, 0, 0.08);
   padding-bottom: 16px;
 }
 
-.login-form__social-link:hover {
+.auth-form__social-link:hover {
   text-decoration: none;
 }
 
-.login-form__recaptcha-terms {
+.auth-form__recaptcha-terms {
   display: block;
   font-style: normal;
   font-weight: 400;

--- a/public/css/app.css
+++ b/public/css/app.css
@@ -10997,3 +10997,95 @@ a.text-dark:focus {
   color: #a0a0a0;
 }
 
+.login-form {
+  margin-top: 50px;
+  padding: 40px 0 38px;
+  background-color: rgba(255, 255, 255, 0.92);
+  border-radius: 4px;
+  text-align: center;
+}
+
+.login-form__logo-box {
+  margin-bottom: 32px;
+}
+
+.login-form__logo {
+  margin-bottom: 6px;
+}
+
+.login-form__catchphrase {
+  color: #757c80;
+  font-size: 12px;
+  font-weight: 700;
+}
+
+.login-form__form-box {
+  margin: 0 15px;
+}
+
+.login-form__field {
+  border-radius: 4px 4px 0 0;
+}
+
+.login-form__input {
+  color: #757c80;
+}
+
+.login-form__reset-box {
+  display: block;
+  margin: 0 auto;
+  width: 100%;
+  box-sizing: border-box;
+}
+
+.login-form__reset-link {
+  display: block;
+  margin-left: auto;
+  text-align: right;
+  font-size: 12px;
+}
+
+.login-form__social {
+  border-bottom: 1px solid rgba(0, 0, 0, 0.08);
+  padding-bottom: 16px;
+}
+
+.login-form__social-link:hover {
+  text-decoration: none;
+}
+
+.login-form__recaptcha-terms {
+  display: block;
+  font-style: normal;
+  font-weight: 400;
+  font-size: 12px;
+  line-height: 16px;
+  text-align: center;
+  color: rgba(0, 0, 0, 0.32);
+  margin: 0 auto;
+  padding-top: 14px;
+  width: 100%;
+  box-sizing: border-box;
+}
+
+.auth-button {
+  display: block;
+  margin: 10px auto 5px;
+  height: 40px;
+  border-radius: 22px;
+  border-style: none;
+  color: #fff;
+  outline: none;
+  font-weight: 700;
+  font-size: 14px;
+  text-align: center;
+  transition: 0.3s;
+  width: 100%;
+  box-sizing: border-box;
+}
+
+.auth-button:hover {
+  opacity: 0.8;
+  color: #f8f9fa;
+}
+

--- a/resources/sass/app.scss
+++ b/resources/sass/app.scss
@@ -12,3 +12,7 @@
 @import 'button';
 
 @import 'posts/comment';
+
+@import 'auth/login-form';
+
+@import 'auth/auth-button';

--- a/resources/sass/app.scss
+++ b/resources/sass/app.scss
@@ -13,6 +13,6 @@
 
 @import 'posts/comment';
 
-@import 'auth/login-form';
+@import 'auth/auth-form';
 
 @import 'auth/auth-button';

--- a/resources/sass/auth/_auth-button.scss
+++ b/resources/sass/auth/_auth-button.scss
@@ -1,0 +1,21 @@
+.auth-button {
+  display: block;
+  margin: 10px auto 5px;
+  height: 40px;
+  border-radius: 22px;
+  border-style: none;
+  color: #fff;
+  outline: none;
+  font-weight: 700;
+  font-size: 14px;
+  text-align: center;
+  transition: .3s;
+  width: 100%;
+  -webkit-box-sizing: border-box;
+  -moz-box-sizing: border-box;
+  box-sizing: border-box;
+  &:hover {
+    opacity: 0.8;
+    color: #f8f9fa;
+  }
+}

--- a/resources/sass/auth/_auth-button.scss
+++ b/resources/sass/auth/_auth-button.scss
@@ -1,6 +1,6 @@
 .auth-button {
   display: block;
-  margin: 10px auto 5px;
+  margin: 14px auto 5px;
   height: 40px;
   border-radius: 22px;
   border-style: none;

--- a/resources/sass/auth/_auth-form.scss
+++ b/resources/sass/auth/_auth-form.scss
@@ -22,6 +22,12 @@
     font-size: 20px;
     font-weight: 700;
   }
+  &__discription {
+    margin-top: -16px;
+    color: #757c80;
+    font-size: 10px;
+    font-weight: 700;
+  }
   &__form-box {
     margin: 0 15px;
   }

--- a/resources/sass/auth/_auth-form.scss
+++ b/resources/sass/auth/_auth-form.scss
@@ -15,6 +15,13 @@
     font-size: 12px;
     font-weight: 700;
   }
+  &__title {
+    margin-top: -8px;
+    margin-bottom: 30px;
+    color: #757c80;
+    font-size: 20px;
+    font-weight: 700;
+  }
   &__form-box {
     margin: 0 15px;
   }
@@ -42,6 +49,7 @@
   &__social {
     border-bottom: 1px solid rgba(0,0,0,.08);
     padding-bottom: 16px;
+    margin-top: 16px;
   }
   &__social-link {
     &:hover {

--- a/resources/sass/auth/_auth-form.scss
+++ b/resources/sass/auth/_auth-form.scss
@@ -1,4 +1,4 @@
-.login-form {
+.auth-form {
   margin-top: 50px;
   padding: 40px 0 38px;
   background-color: hsla(0,0%,100%,.92);

--- a/resources/sass/auth/_login-form.scss
+++ b/resources/sass/auth/_login-form.scss
@@ -1,0 +1,66 @@
+.login-form {
+  margin-top: 50px;
+  padding: 40px 0 38px;
+  background-color: hsla(0,0%,100%,.92);
+  border-radius: 4px;
+  text-align: center;
+  &__logo-box {
+    margin-bottom: 32px;
+  }
+  &__logo {
+    margin-bottom: 6px;
+  }
+  &__catchphrase {
+    color: #757c80;
+    font-size: 12px;
+    font-weight: 700;
+  }
+  &__form-box {
+    margin: 0 15px;
+  }
+  &__field {
+    border-radius: 4px 4px 0 0;
+  }
+  &__input {
+    color: #757c80;
+  }
+  &__reset-box {
+    display: block;
+    margin: 0 auto;
+    width: 100%;
+    -webkit-box-sizing: border-box;
+    -moz-box-sizing: border-box;
+    box-sizing: border-box;
+  }
+  &__reset-link {
+    display: block;
+    margin-left: auto;
+    text-align: right;
+    font-size: 12px;
+    
+  }
+  &__social {
+    border-bottom: 1px solid rgba(0,0,0,.08);
+    padding-bottom: 16px;
+  }
+  &__social-link {
+    &:hover {
+      text-decoration: none;
+    }
+  }
+  &__recaptcha-terms {
+    display: block;
+    font-style: normal;
+    font-weight: 400;
+    font-size: 12px;
+    line-height: 16px;
+    text-align: center;
+    color: rgba(0,0,0,.32);
+    margin: 0 auto;
+    padding-top: 14px;
+    width: 100%;
+    -webkit-box-sizing: border-box;
+    -moz-box-sizing: border-box;
+    box-sizing: border-box;
+  }
+}

--- a/resources/views/auth/login.blade.php
+++ b/resources/views/auth/login.blade.php
@@ -3,74 +3,55 @@
 @section('content')
 <div class="container">
     <div class="row justify-content-center">
-        <div class="col-md-8">
-            <div class="card">
-                <div class="card-header text-center font-weight-bold">{{ __('ログイン') }}</div>
+        <div class="col-md-4 login-form">
+            <div class="login-form__logo-box">
+                <div class="login-form__logo">
+                    <img src="https://illust-station-takiterina-bucket.s3-ap-northeast-1.amazonaws.com/logo_middle_size.png" class="img-fluid" alt="ロゴ">
+                </div>
+                <div class="login-form__catchphrase">好きを描く</div>
+            </div>
+            <div class="login-form__form-box">
+                <form method="POST" action="{{ route('login') }}">
+                    @csrf
+                        <div class="col-md-12 login-form__field">
+                            <input id="email" type="email" class="form-control login-form__input @error('email') is-invalid @enderror" name="email" value="{{ old('email') }}" required autocomplete="email" autofocus placeholder="メールアドレス">
 
-                <div class="card-body">
-                    <form method="POST" action="{{ route('login') }}">
-                        @csrf
-
-                        <div class="form-group row">
-                            <label for="email" class="col-md-4 col-form-label text-md-right">{{ __('メールアドレス') }}</label>
-
-                            <div class="col-md-6">
-                                <input id="email" type="email" class="form-control @error('email') is-invalid @enderror" name="email" value="{{ old('email') }}" required autocomplete="email" autofocus>
-
-                                @error('email')
-                                    <span class="invalid-feedback" role="alert">
-                                        <strong>{{ $message }}</strong>
-                                    </span>
-                                @enderror
-                            </div>
+                            @error('email')
+                                <span class="invalid-feedback" role="alert">
+                                    <strong>{{ $message }}</strong>
+                                </span>
+                            @enderror
                         </div>
+                        <div class="col-md-12 login-form__field">
+                            <input id="password" type="password" class="form-control login-form__input @error('password') is-invalid @enderror" name="password" required autocomplete="current-password" placeholder="パスワード">
 
-                        <div class="form-group row">
-                            <label for="password" class="col-md-4 col-form-label text-md-right">{{ __('パスワード') }}</label>
-
-                            <div class="col-md-6">
-                                <input id="password" type="password" class="form-control @error('password') is-invalid @enderror" name="password" required autocomplete="current-password">
-
-                                @error('password')
-                                    <span class="invalid-feedback" role="alert">
-                                        <strong>{{ $message }}</strong>
-                                    </span>
-                                @enderror
-                            </div>
+                            @error('password')
+                                <span class="invalid-feedback" role="alert">
+                                    <strong>{{ $message }}</strong>
+                                </span>
+                            @enderror
                         </div>
+                        
+                        <button type="submit" class="btn font-weight-bold auth-button" style="background-color: #295d72;">
+                            {{ __('ログイン') }}
+                        </button>
 
-                        <div class="form-group row">
-                            <div class="col-md-6 offset-md-4">
-                                <div class="form-check">
-                                    <input class="form-check-input" type="checkbox" name="remember" id="remember" {{ old('remember') ? 'checked' : '' }}>
-
-                                    <label class="form-check-label" for="remember">
-                                        {{ __('記憶する') }}
-                                    </label>
-                                </div>
-                            </div>
-                        </div>
-
-                        <div class="form-group row mb-0">
-                            <div class="col-md-8 offset-md-4">
-                                <button type="submit" class="btn font-weight-bold button-design">
-                                    {{ __('ログインする') }}
-                                </button>
-
-                                @if (Route::has('password.request'))
-                                    <a class="btn btn-link" style="color: #295d72;" href="{{ route('password.request') }}">
-                                        {{ __('パスワードを忘れた方はこちら') }}
-                                    </a>
-                                @endif
-                            </div>
-                            <div class="col-md-8 offset-md-4 mt-3">
-                                <a href="/login/twitter">
-                                    <button type="button" class="btn font-weight-bold button-design">Twiiterログイン</button>
+                        @if (Route::has('password.request'))
+                            <div class="login-form__reset-box">
+                                <a class="btn btn-link login-form__reset-link" style="color: #295d72;" href="{{ route('password.request') }}">
+                                    {{ __('パスワードがわからない') }}
                                 </a>
                             </div>
+                        @endif
+                        <div class="login-form__social">
+                            <a href="/login/twitter" class="login-form__social-link">
+                                <button type="button" class="btn font-weight-bold auth-button"style="background-color: #0096fa;">Twiiterで続ける</button>
+                            </a>
                         </div>
-                    </form>
-                </div>
+                        <div class="login-form__recaptcha-terms">
+                            This site is protected by Akimine
+                        </div>
+                </form>
             </div>
         </div>
     </div>

--- a/resources/views/auth/login.blade.php
+++ b/resources/views/auth/login.blade.php
@@ -3,18 +3,18 @@
 @section('content')
 <div class="container">
     <div class="row justify-content-center">
-        <div class="col-md-4 login-form">
-            <div class="login-form__logo-box">
-                <div class="login-form__logo">
+        <div class="col-md-4 auth-form">
+            <div class="auth-form__logo-box">
+                <div class="auth-form__logo">
                     <img src="https://illust-station-takiterina-bucket.s3-ap-northeast-1.amazonaws.com/logo_middle_size.png" class="img-fluid" alt="ロゴ">
                 </div>
-                <div class="login-form__catchphrase">好きを描く</div>
+                <div class="auth-form__catchphrase">好きを描く</div>
             </div>
-            <div class="login-form__form-box">
+            <div class="auth-form__form-box">
                 <form method="POST" action="{{ route('login') }}">
                     @csrf
-                        <div class="col-md-12 login-form__field">
-                            <input id="email" type="email" class="form-control login-form__input @error('email') is-invalid @enderror" name="email" value="{{ old('email') }}" required autocomplete="email" autofocus placeholder="メールアドレス">
+                        <div class="col-md-12 auth-form__field">
+                            <input id="email" type="email" class="form-control auth-form__input @error('email') is-invalid @enderror" name="email" value="{{ old('email') }}" required autocomplete="email" autofocus placeholder="メールアドレス">
 
                             @error('email')
                                 <span class="invalid-feedback" role="alert">
@@ -22,8 +22,8 @@
                                 </span>
                             @enderror
                         </div>
-                        <div class="col-md-12 login-form__field">
-                            <input id="password" type="password" class="form-control login-form__input @error('password') is-invalid @enderror" name="password" required autocomplete="current-password" placeholder="パスワード">
+                        <div class="col-md-12 auth-form__field">
+                            <input id="password" type="password" class="form-control auth-form__input @error('password') is-invalid @enderror" name="password" required autocomplete="current-password" placeholder="パスワード">
 
                             @error('password')
                                 <span class="invalid-feedback" role="alert">
@@ -37,18 +37,18 @@
                         </button>
 
                         @if (Route::has('password.request'))
-                            <div class="login-form__reset-box">
-                                <a class="btn btn-link login-form__reset-link" style="color: #295d72;" href="{{ route('password.request') }}">
+                            <div class="auth-form__reset-box">
+                                <a class="btn btn-link auth-form__reset-link" style="color: #295d72;" href="{{ route('password.request') }}">
                                     {{ __('パスワードがわからない') }}
                                 </a>
                             </div>
                         @endif
-                        <div class="login-form__social">
-                            <a href="/login/twitter" class="login-form__social-link">
-                                <button type="button" class="btn font-weight-bold auth-button"style="background-color: #0096fa;">Twiiterで続ける</button>
+                        <div class="auth-form__social">
+                            <a href="/login/twitter" class="auth-form__social-link">
+                                <button type="button" class="btn font-weight-bold auth-button" style="background-color: #0096fa;">Twiiterで続ける</button>
                             </a>
                         </div>
-                        <div class="login-form__recaptcha-terms">
+                        <div class="auth-form__recaptcha-terms">
                             This site is protected by Akimine
                         </div>
                 </form>

--- a/resources/views/auth/login.blade.php
+++ b/resources/views/auth/login.blade.php
@@ -38,7 +38,7 @@
 
                         @if (Route::has('password.request'))
                             <div class="auth-form__reset-box">
-                                <a class="btn btn-link auth-form__reset-link" style="color: #295d72;" href="{{ route('password.request') }}">
+                                <a class="auth-form__reset-link" style="color: #295d72;" href="{{ route('password.request') }}">
                                     {{ __('パスワードがわからない') }}
                                 </a>
                             </div>

--- a/resources/views/auth/passwords/email.blade.php
+++ b/resources/views/auth/passwords/email.blade.php
@@ -3,45 +3,53 @@
 @section('content')
 <div class="container">
     <div class="row justify-content-center">
-        <div class="col-md-8">
-            <div class="card">
-                <div class="card-header text-center font-weight-bold">{{ __('パスワードをリセットする') }}</div>
-
-                <div class="card-body">
-                    @if (session('status'))
-                        <div class="alert alert-success" role="alert">
-                            {{ session('status') }}
-                        </div>
-                    @endif
-
-                    <form method="POST" action="{{ route('password.email') }}">
-                        @csrf
-
-                        <div class="form-group row">
-                            <label for="email" class="col-md-4 col-form-label text-md-right">{{ __('メールアドレス') }}</label>
-
-                            <div class="col-md-6">
-                                <input id="email" type="email" class="form-control @error('email') is-invalid @enderror" name="email" value="{{ old('email') }}" required autocomplete="email" autofocus>
-
-                                @error('email')
-                                    <span class="invalid-feedback" role="alert">
-                                        <strong>{{ $message }}</strong>
-                                    </span>
-                                @enderror
-                            </div>
-                        </div>
-
-                        <div class="form-group row mb-0">
-                            <div class="col-md-6 offset-md-4">
-                                <button type="submit" class="btn font-weight-bold" style="color: #f8f9fa; background-color: #295d72;">
-                                    {{ __('パスワード再登録のリンクを送る') }}
-                                </button>
-                            </div>
-                        </div>
-                    </form>
+        <div class="col-md-4 auth-form">
+            <div class="auth-form__logo-box">
+                <div class="auth-form__logo">
+                    <img src="https://illust-station-takiterina-bucket.s3-ap-northeast-1.amazonaws.com/logo_middle_size.png" class="img-fluid" alt="ロゴ">
                 </div>
+                <div class="auth-form__catchphrase">好きを描く</div>
             </div>
+            <div class="auth-form__title">パスワードを再設定する</div>
+            <div class="auth-form__discription">登録したメールアドレスを入力してください</div>
+            
+            <div class="card-body">
+                @if (session('status'))
+                    <div class="alert alert-success" role="alert">
+                        {{ session('status') }}
+                    </div>
+                @endif
+            </div>
+
+            <div class="auth-form__form-box">
+                <form method="POST" action="{{ route('password.email') }}">
+                    @csrf
+
+                        <div class="col-md-12 auth-form__field">
+                            <input id="email" type="email" class="form-control auth-form__input @error('email') is-invalid @enderror" name="email" value="{{ old('email') }}" required autocomplete="email" autofocus placeholder="メールアドレス">
+
+                            @error('email')
+                                <span class="invalid-feedback" role="alert">
+                                    <strong>{{ $message }}</strong>
+                                </span>
+                            @enderror
+                        </div>
+
+                        <button type="submit" class="btn font-weight-bold auth-button" style="background-color: #295d72;">
+                            {{ __('再設定リンクを送信する') }}
+                        </button>
+
+                        <div class="auth-form__social">
+                        </div>
+                        
+                        <div class="auth-form__recaptcha-terms">
+                            This site is protected by Akimine
+                        </div>
+                </form>
+            </div>
+            
         </div>
     </div>
 </div>
+
 @endsection

--- a/resources/views/auth/passwords/reset.blade.php
+++ b/resources/views/auth/passwords/reset.blade.php
@@ -3,63 +3,64 @@
 @section('content')
 <div class="container">
     <div class="row justify-content-center">
-        <div class="col-md-8">
-            <div class="card">
-                <div class="card-header text-center font-weight-bold">{{ __('パスワードをリセットする') }}</div>
+        <div class="col-md-4 auth-form">
+            <div class="auth-form__logo-box">
+                <div class="auth-form__logo">
+                    <img src="https://illust-station-takiterina-bucket.s3-ap-northeast-1.amazonaws.com/logo_middle_size.png" class="img-fluid" alt="ロゴ">
+                </div>
+                <div class="auth-form__catchphrase">好きを描く</div>
+            </div>
+            <div class="auth-form__title">パスワードをリセットする</div>
 
-                <div class="card-body">
-                    <form method="POST" action="{{ route('password.update') }}">
-                        @csrf
-
+            <div class="auth-form__form-box">
+                <form method="POST" action="{{ route('password.update') }}">
+                    @csrf
                         <input type="hidden" name="token" value="{{ $token }}">
 
-                        <div class="form-group row">
-                            <label for="email" class="col-md-4 col-form-label text-md-right">{{ __('メールアドレス') }}</label>
+                        <div class="col-md-12 auth-form__field">
+                            <input id="email" type="email" class="form-control auth-form__input @error('email') is-invalid @enderror" name="email" value="{{ $email ?? old('email') }}" required autocomplete="email" autofocus placeholder="メールアドレス">
 
-                            <div class="col-md-6">
-                                <input id="email" type="email" class="form-control @error('email') is-invalid @enderror" name="email" value="{{ $email ?? old('email') }}" required autocomplete="email" autofocus>
-
-                                @error('email')
-                                    <span class="invalid-feedback" role="alert">
-                                        <strong>{{ $message }}</strong>
-                                    </span>
-                                @enderror
-                            </div>
+                            @error('email')
+                                <span class="invalid-feedback" role="alert">
+                                    <strong>{{ $message }}</strong>
+                                </span>
+                            @enderror
                         </div>
 
-                        <div class="form-group row">
-                            <label for="password" class="col-md-4 col-form-label text-md-right">{{ __('パスワード') }}</label>
+                        <div class="col-md-12 auth-form__field">
+                            <input id="password" type="password" class="form-control auth-form__input @error('password') is-invalid @enderror" name="password" required autocomplete="new-password" placeholder="パスワード">
 
-                            <div class="col-md-6">
-                                <input id="password" type="password" class="form-control @error('password') is-invalid @enderror" name="password" required autocomplete="new-password">
-
-                                @error('password')
-                                    <span class="invalid-feedback" role="alert">
-                                        <strong>{{ $message }}</strong>
-                                    </span>
-                                @enderror
-                            </div>
+                            @error('password')
+                                <span class="invalid-feedback" role="alert">
+                                    <strong>{{ $message }}</strong>
+                                </span>
+                            @enderror
                         </div>
 
-                        <div class="form-group row">
-                            <label for="password-confirm" class="col-md-4 col-form-label text-md-right">{{ __('（確認用）パスワード') }}</label>
+                        <div class="col-md-12 auth-form__field">
+                            <input id="password-confirm" type="password" class="form-control auth-form__input" name="password_confirmation" required autocomplete="new-password" placeholder="パスワード(確認用)">
 
-                            <div class="col-md-6">
-                                <input id="password-confirm" type="password" class="form-control" name="password_confirmation" required autocomplete="new-password">
-                            </div>
+                            @error('password')
+                                <span class="invalid-feedback" role="alert">
+                                    <strong>{{ $message }}</strong>
+                                </span>
+                            @enderror
                         </div>
 
-                        <div class="form-group row mb-0">
-                            <div class="col-md-6 offset-md-4">
-                                <button type="submit" class="btn font-weight-bold" style="color: #f8f9fa; background-color: #295d72;">
-                                    {{ __('パスワードをリセットする') }}
-                                </button>
-                            </div>
+                        <button type="submit" class="btn font-weight-bold auth-button" style="background-color: #295d72;">
+                            {{ __('パスワードをリセットする') }}
+                        </button>
+
+                        <div class="auth-form__social">
                         </div>
-                    </form>
-                </div>
+                        
+                        <div class="auth-form__recaptcha-terms">
+                            This site is protected by Akimine
+                        </div>
+                </form>
             </div>
         </div>
     </div>
 </div>
+
 @endsection

--- a/resources/views/auth/register.blade.php
+++ b/resources/views/auth/register.blade.php
@@ -3,75 +3,75 @@
 @section('content')
 <div class="container">
     <div class="row justify-content-center">
-        <div class="col-md-8">
-            <div class="card">
-                <div class="card-header text-center font-weight-bold">{{ __('ユーザー登録') }}</div>
-
-                <div class="card-body">
-                    <form method="POST" action="{{ route('register') }}">
-                        @csrf
-
-                        <div class="form-group row">
-                            <label for="name" class="col-md-4 col-form-label text-md-right">{{ __('名前') }}</label>
-
-                            <div class="col-md-6">
-                                <input id="name" type="text" class="form-control @error('name') is-invalid @enderror" name="name" value="{{ old('name') }}" required autocomplete="name" autofocus>
-
-                                @error('name')
-                                    <span class="invalid-feedback" role="alert">
-                                        <strong>{{ $message }}</strong>
-                                    </span>
-                                @enderror
-                            </div>
-                        </div>
-
-                        <div class="form-group row">
-                            <label for="email" class="col-md-4 col-form-label text-md-right">{{ __('メールアドレス') }}</label>
-
-                            <div class="col-md-6">
-                                <input id="email" type="email" class="form-control @error('email') is-invalid @enderror" name="email" value="{{ old('email') }}" required autocomplete="email">
-
-                                @error('email')
-                                    <span class="invalid-feedback" role="alert">
-                                        <strong>{{ $message }}</strong>
-                                    </span>
-                                @enderror
-                            </div>
-                        </div>
-
-                        <div class="form-group row">
-                            <label for="password" class="col-md-4 col-form-label text-md-right">{{ __('パスワード') }}</label>
-
-                            <div class="col-md-6">
-                                <input id="password" type="password" class="form-control @error('password') is-invalid @enderror" name="password" required autocomplete="new-password">
-
-                                @error('password')
-                                    <span class="invalid-feedback" role="alert">
-                                        <strong>{{ $message }}</strong>
-                                    </span>
-                                @enderror
-                            </div>
-                        </div>
-
-                        <div class="form-group row">
-                            <label for="password-confirm" class="col-md-4 col-form-label text-md-right">{{ __('（確認用）パスワード') }}</label>
-
-                            <div class="col-md-6">
-                                <input id="password-confirm" type="password" class="form-control" name="password_confirmation" required autocomplete="new-password">
-                            </div>
-                        </div>
-
-                        <div class="form-group row mb-0">
-                            <div class="col-md-6 offset-md-4">
-                                <button type="submit" class="btn font-weight-bold button-design">
-                                    {{ __('登録する') }}
-                                </button>
-                            </div>
-                        </div>
-                    </form>
+        <div class="col-md-4 auth-form">
+            <div class="auth-form__logo-box">
+                <div class="auth-form__logo">
+                    <img src="https://illust-station-takiterina-bucket.s3-ap-northeast-1.amazonaws.com/logo_middle_size.png" class="img-fluid" alt="ロゴ">
                 </div>
+                <div class="auth-form__catchphrase">好きを描く</div>
+            </div>
+            <div class="auth-form__title">アカウント作成</div>
+            
+            <div class="auth-form__form-box">
+                <form method="POST" action="{{ route('register') }}">
+                    @csrf
+                        <div class="col-md-12 auth-form__field">
+                            <input id="name" type="text" class="form-control auth-form__input @error('name') is-invalid @enderror" name="name" value="{{ old('name') }}" required autocomplete="name" autofocus placeholder="名前">
+
+                            @error('name')
+                                <span class="invalid-feedback" role="alert">
+                                    <strong>{{ $message }}</strong>
+                                </span>
+                            @enderror
+                        </div>
+
+                        <div class="col-md-12 auth-form__field">
+                            <input id="email" type="email" class="form-control auth-form__input @error('email') is-invalid @enderror" name="email" value="{{ old('email') }}" required autocomplete="email" autofocus placeholder="メールアドレス">
+
+                            @error('email')
+                                <span class="invalid-feedback" role="alert">
+                                    <strong>{{ $message }}</strong>
+                                </span>
+                            @enderror
+                        </div>
+
+                        <div class="col-md-12 auth-form__field">
+                            <input id="password" type="password" class="form-control auth-form__input @error('password') is-invalid @enderror" name="password" required autocomplete="new-password" placeholder="パスワード">
+
+                            @error('password')
+                                <span class="invalid-feedback" role="alert">
+                                    <strong>{{ $message }}</strong>
+                                </span>
+                            @enderror
+                        </div>
+
+                        <div class="col-md-12 auth-form__field">
+                            <input id="password-confirm" type="password" class="form-control auth-form__input" name="password_confirmation" required autocomplete="new-password" placeholder="パスワード(確認用)">
+
+                            @error('password')
+                                <span class="invalid-feedback" role="alert">
+                                    <strong>{{ $message }}</strong>
+                                </span>
+                            @enderror
+                        </div>
+
+                        <button type="submit" class="btn font-weight-bold auth-button" style="background-color: #295d72;">
+                            {{ __('登録') }}
+                        </button>
+
+                        <div class="auth-form__social">
+                            <a href="/login/twitter" class="auth-form__social-link">
+                                <button type="button" class="btn font-weight-bold auth-button" style="background-color: #0096fa;">Twiiterで続ける</button>
+                            </a>
+                        </div>
+                        
+                        <div class="auth-form__recaptcha-terms">
+                            This site is protected by Akimine
+                        </div>
+                </form>
             </div>
         </div>
     </div>
 </div>
+
 @endsection


### PR DESCRIPTION
# What
認証ページのデザインを修正する
- ログイン、ユーザー登録、パスワードリセット及びパスワード再設定ページを修正した
- 認証で用いるボタンのデザイン、フォームのデザインをscssを用いてまとめた
- パスワードリセット後のリダイレクト先をトップページに修正した

# Why
認証ページのビューが簡素であったので、ユーザーにとってシンプルで使いやすくするため。

<img width="1199" alt="c2c24242c52c0f647c03ded0208b17f5" src="https://user-images.githubusercontent.com/52768993/121778973-6c92d700-cbd4-11eb-8448-63c21782a0ec.png">
