### PR TITLE
Make:【サーバーサイド】タグ機能

### DIFF
--- a/app/Http/Controllers/PostController.php
+++ b/app/Http/Controllers/PostController.php
@@ -4,6 +4,7 @@ namespace App\Http\Controllers;
 
 use Illuminate\Http\Request;
 use App\Models\Post;
+use App\Models\Tag;
 use Illuminate\Support\Facades\Auth;
 use App\Http\Requests\StorePost;
 use Illuminate\Support\Facades\Storage;
@@ -66,11 +67,26 @@ class PostController extends Controller
             $post->image = "";
         }
 
+       preg_match_all('/#([a-zA-z0-9０-９ぁ-んァ-ヶ亜-熙]+)/u', $request->tags, $match);
+
+       $tags = [];
+       foreach($match[1] as $tag) {
+           $record = Tag::firstOrCreate(['name' => $tag]);
+           array_push($tags, $record);
+       }
+
+       $tags_id = [];
+       foreach($tags as $tag) {
+           array_push($tags_id, $tag->id);
+       }
+        
         $post->title = $request->input('title');
         $post->content = $request->input('content');
         $post->user_id = Auth::user()->id;
 
         $post->save();
+
+        $post->tag()->attach($tags_id);
 
         return redirect('/');
     }

--- a/app/Http/Controllers/TagController.php
+++ b/app/Http/Controllers/TagController.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use Illuminate\Http\Request;
+use App\Models\Tag;
+
+class TagController extends Controller
+{
+    public function show($id) {
+
+        $tag = Tag::find($id);
+        return view('tags.show', compact('tag'));
+    }
+}

--- a/app/Models/Post.php
+++ b/app/Models/Post.php
@@ -20,6 +20,6 @@ class Post extends Model
 
     public function tag()
     {
-        return $this->belongsToMany('App\Models\Tag'); 
+        return $this->belongsToMany('App\Models\Tag', 'post_tags'); 
     }
 }

--- a/app/Models/Post.php
+++ b/app/Models/Post.php
@@ -17,4 +17,9 @@ class Post extends Model
     {
         return $this->hasMany('App\Models\Comment');
     }
+
+    public function tag()
+    {
+        return $this->belongsToMany('App\Models\Tag'); 
+    }
 }

--- a/app/Models/Post_tag.php
+++ b/app/Models/Post_tag.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace App;
+
+use Illuminate\Database\Eloquent\Model;
+
+class Post_tag extends Model
+{
+    protected $fillable = ['post_id', 'tag_id'];
+}

--- a/app/Models/Tag.php
+++ b/app/Models/Tag.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace App;
+namespace App\Models;
 
 use Illuminate\Database\Eloquent\Model;
 

--- a/app/Models/Tag.php
+++ b/app/Models/Tag.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace App;
+
+use Illuminate\Database\Eloquent\Model;
+
+class Tag extends Model
+{
+    //
+}

--- a/app/Models/Tag.php
+++ b/app/Models/Tag.php
@@ -6,5 +6,8 @@ use Illuminate\Database\Eloquent\Model;
 
 class Tag extends Model
 {
-    //
+    public function post()
+    {
+        return $this->belongsToMany('App\Models\Post'); 
+    }
 }

--- a/app/Models/Tag.php
+++ b/app/Models/Tag.php
@@ -6,6 +6,8 @@ use Illuminate\Database\Eloquent\Model;
 
 class Tag extends Model
 {
+    protected $fillable = ['name'];
+
     public function post()
     {
         return $this->belongsToMany('App\Models\Post'); 

--- a/app/Models/Tag.php
+++ b/app/Models/Tag.php
@@ -10,6 +10,6 @@ class Tag extends Model
 
     public function post()
     {
-        return $this->belongsToMany('App\Models\Post'); 
+        return $this->belongsToMany('App\Models\Post', 'post_tags'); 
     }
 }

--- a/database/migrations/2021_06_13_191353_create_tags_table.php
+++ b/database/migrations/2021_06_13_191353_create_tags_table.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class CreateTagsTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('tags', function (Blueprint $table) {
+            $table->bigIncrements('id');
+            $table->timestamps();
+            $table->string('name');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('tags');
+    }
+}

--- a/database/migrations/2021_06_13_194750_create_post_tag_table.php
+++ b/database/migrations/2021_06_13_194750_create_post_tag_table.php
@@ -1,0 +1,31 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class CreatePostTagTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('post_tag', function (Blueprint $table) {
+            $table->bigIncrements('id');
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('post_tag');
+    }
+}

--- a/database/migrations/2021_06_13_194750_create_post_tag_table.php
+++ b/database/migrations/2021_06_13_194750_create_post_tag_table.php
@@ -13,7 +13,7 @@ class CreatePostTagTable extends Migration
      */
     public function up()
     {
-        Schema::create('post_tag', function (Blueprint $table) {
+        Schema::create('post_tags', function (Blueprint $table) {
             $table->bigIncrements('id');
             $table->timestamps();
             $table->bigInteger('tag_id')->unsigned();
@@ -30,6 +30,6 @@ class CreatePostTagTable extends Migration
      */
     public function down()
     {
-        Schema::dropIfExists('post_tag');
+        Schema::dropIfExists('post_tags');
     }
 }

--- a/database/migrations/2021_06_13_194750_create_post_tag_table.php
+++ b/database/migrations/2021_06_13_194750_create_post_tag_table.php
@@ -16,6 +16,10 @@ class CreatePostTagTable extends Migration
         Schema::create('post_tag', function (Blueprint $table) {
             $table->bigIncrements('id');
             $table->timestamps();
+            $table->bigInteger('tag_id')->unsigned();
+            $table->bigInteger('post_id')->unsigned();
+            $table->foreign('tag_id')->references('id')->on('tags')->onDelete('cascade');
+            $table->foreign('post_id')->references('id')->on('posts')->onDelete('cascade');
         });
     }
 

--- a/resources/views/posts/create.blade.php
+++ b/resources/views/posts/create.blade.php
@@ -33,7 +33,7 @@
                       <br>
                       <label class="mt-2" for="tags">タグ</label>
                       <br>
-                      <input type="text" name="tags" id="tags">
+                      <input type="text" name="tags" id="tags" value="#">
                       <br>
                       <label class="mt-2" for="content">内容</label>
                       <br>

--- a/resources/views/posts/create.blade.php
+++ b/resources/views/posts/create.blade.php
@@ -31,6 +31,10 @@
                       <br>
                       <input type="text" name="title" id="title">
                       <br>
+                      <label class="mt-2" for="tags">タグ</label>
+                      <br>
+                      <input type="text" name="tags" id="tags">
+                      <br>
                       <label class="mt-2" for="content">内容</label>
                       <br>
                       <textarea name="content" id="content" cols="50" rows="5"></textarea>

--- a/resources/views/posts/show.blade.php
+++ b/resources/views/posts/show.blade.php
@@ -34,7 +34,9 @@
 
                     <div class="mt-2">
                         @foreach($post->tag as $post_tag)
+                            <a href="{{ route('tags.show', ['id' => $post_tag->id]) }}">
                             <span class="ml-3">#{{$post_tag->name}}</span>
+                            </a>
                         @endforeach
                     </div>
 

--- a/resources/views/posts/show.blade.php
+++ b/resources/views/posts/show.blade.php
@@ -27,9 +27,15 @@
                     
                     <div class="border-bottom pb-2">
                     <span class="ml-3" >{{ $post->user->name}}：：</span>{{ $post->content}}</div>
+
                     <div class="border-bottom pt-2 pb-2">
-                    
                     <span class="ml-3">投稿日：：</span>{{ $post->created_at}}
+                    </div>
+
+                    <div class="mt-2">
+                        @foreach($post->tag as $post_tag)
+                            <span class="ml-3">#{{$post_tag->name}}</span>
+                        @endforeach
                     </div>
 
                     {{-- 現在ログインしているユーザーの投稿であれば表示する --}}

--- a/resources/views/tags/show.blade.php
+++ b/resources/views/tags/show.blade.php
@@ -1,0 +1,55 @@
+@extends('layouts.app')
+
+@section('content')
+<div class="container">
+    <div class="row justify-content-center">
+        <div class="col-md-12">
+            <div class="card">
+
+                <div class="card-body">
+                    @if (session('status'))
+                        <div class="alert alert-success" role="alert">
+                            {{ session('status') }}
+                        </div>
+                    @endif
+                    <nav class="navbar navbar-expand-lg navbar-light bg-light">
+                        <div class="container-fluid">
+                            <div class="font-weight-bold">
+                                #{{$tag->name}}
+                            </div>
+                        </div>
+                    </nav>
+                      
+                    <table class="table">
+                      
+                    </table>
+                    
+                    <div class="row row-cols-1 row-cols-md-3 g-4">
+                        @foreach($tag->post as $post)
+                            <div class="col mb-4">
+                                <div class="card h-100">
+                                    <a href="{{ route('posts.show', ['id' => $post->id]) }}">
+                                        @if($post->image == null)
+                                            <img class="card-img-top" src="/storage/no-image.png" >
+                                        @else
+                                            <img class="card-img-top" src="{{$post->image}}" >
+                                        @endif
+                                    </a>
+                                    <div class="card-body">
+                                        <h5 class="card-title">{{ Str::limit($post->title, 20, '(…)' )}}</h5>
+                                        <p class="card-text">{{ Str::limit($post->content, 60, '(…)' )}}</p>
+                                    </div>
+                                    <div class="card-footer">
+                                        <small class="text-muted">{{ $post->user->name}}</small>
+                                    </div>
+                                </div>
+                            </div>
+                        @endforeach
+                    </div>
+                  
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+@endsection

--- a/routes/web.php
+++ b/routes/web.php
@@ -38,6 +38,8 @@ Route::group(['middleware' => 'auth'], function(){
     Route::post('store', 'CommentController@store')->name('comments.store');
 });
 
+Route::get('tags/show/{id}', 'TagController@show')->name('tags.show');
+
 Route::get('login/twitter', 'Auth\LoginController@redirectToTwitterProvider');
 Route::get('login/twitter/callback', 'Auth\LoginController@handleTwitterProviderCallback');
 


### PR DESCRIPTION
# What
投稿にタグをつけ、さらに同じタグをつけられた投稿を一覧で表示できる機能を実装する。
- tagsテーブルとpostsテーブルとtagsテーブルの中間テーブルであるpost_tagsテーブルを作成する。
- それぞれのmodelにリレーションを設定する。
- 投稿作成ページにタグのフォームを追加する。
- postコントローラーで入力されたタグの情報をリレーションを組んでいるtagsテーブルとpost_tagsテーブルに保存する処理を記述する。
- 投稿詳細ページにタグの表示を追加する。
- 同じタグをつけられた投稿を一覧で表示するページのルーティング、コントローラー及びビューを作成する。

# Why
- 関連性のある投稿を一括で見つけることができるため
- ユーザーが好みのイラストを効率的に探すことができるため