### PR TITLE
Add:【サーバーサイド】タグ編集機能

### DIFF
--- a/app/Http/Controllers/PostController.php
+++ b/app/Http/Controllers/PostController.php
@@ -113,7 +113,8 @@ class PostController extends Controller
     public function edit($id)
     {
         $post = Post::find($id);
-        return view('posts.edit', compact('post'));
+        $tags = $post->tag;
+        return view('posts.edit', compact('post', 'tags'));
     }
 
     /**

--- a/app/Http/Controllers/PostController.php
+++ b/app/Http/Controllers/PostController.php
@@ -67,7 +67,7 @@ class PostController extends Controller
             $post->image = "";
         }
 
-       preg_match_all('/#([a-zA-z0-9０-９ぁ-んァ-ヶ亜-熙]+)/u', $request->tags, $match);
+       preg_match_all('/#([a-zA-z0-9０-９ぁ-んァ-ヶ一-龠]+)/u', $request->tags, $match);
 
        $tags = [];
        foreach($match[1] as $tag) {
@@ -136,7 +136,7 @@ class PostController extends Controller
             $post->image = "";
         }
 
-        preg_match_all('/#([a-zA-z0-9０-９ぁ-んァ-ヶ亜-熙]+)/u', $request->tags, $match);
+        preg_match_all('/#([a-zA-z0-9０-９ぁ-んァ-ヶ一-龠]+)/u', $request->tags, $match);
 
         $before = [];
         foreach($post->tag as $tag){

--- a/app/Http/Controllers/PostController.php
+++ b/app/Http/Controllers/PostController.php
@@ -136,6 +136,25 @@ class PostController extends Controller
             $post->image = "";
         }
 
+        preg_match_all('/#([a-zA-z0-9０-９ぁ-んァ-ヶ亜-熙]+)/u', $request->tags, $match);
+
+        $before = [];
+        foreach($post->tag as $tag){
+            array_push($before, $tag->name);
+        }
+        $after = [];
+        foreach($match[1] as $tag){
+            // 普通に新しいのが来たら新規作成する動き
+            $record = Tag::firstOrCreate(['name' => $tag]);
+            array_push($after, $record);
+        }
+
+        $tags_id = [];
+        foreach($after as $tag) {
+            array_push($tags_id, $tag->id);
+        }
+        $post->tag()->sync($tags_id);
+
         $post->title = $request->input('title');
         $post->content = $request->input('content');
         $post->user_id = Auth::user()->id;

--- a/resources/views/posts/edit.blade.php
+++ b/resources/views/posts/edit.blade.php
@@ -33,7 +33,7 @@
                     <br>
                     <label class="mt-2" for="tags">タグ</label>
                     <br>
-                    <input type="text" name="tags" id="tags" value="#">
+                    <input type="text" name="tags" id="tags" value="@foreach($tags as $tag)#{{$tag->name}}@endforeach">
                     <br>
                     <label for="content" class="mt-2">内容</label>
                     <br>

--- a/resources/views/posts/edit.blade.php
+++ b/resources/views/posts/edit.blade.php
@@ -31,6 +31,10 @@
                     <br>
                     <input type="text" name="title" id="title" value="{{$post->title}}">
                     <br>
+                    <label class="mt-2" for="tags">タグ</label>
+                    <br>
+                    <input type="text" name="tags" id="tags" value="#">
+                    <br>
                     <label for="content" class="mt-2">内容</label>
                     <br>
                     <textarea name="content" id="content" cols="50" rows="5">{{$post->content}}</textarea>


### PR DESCRIPTION
# What
投稿編集ページにタグを編集できる機能を追加する
- 投稿編集ページにタグのフォームを追加しデフォルト値を設定した(プロパティを取得する際はforeachで回してコレクションをモデルに分解) 。
- postコントローラーに編集処理を記述した(重要なのはattachメソッドではなくsyncメソッドを使用すること)。
- 正規表現について[亜-熙]を[一-龠]に変更した。

# Why
タグの内容を変更したい場合、ユーザーが適切なタグをつけることができるようにするため。