### PR TITLE
Add:トップページにタグをランダムに表示する

### DIFF
--- a/app/Http/Controllers/PostController.php
+++ b/app/Http/Controllers/PostController.php
@@ -36,7 +36,7 @@ class PostController extends Controller
 
         $user = Auth::user();
 
-        $tags = Tag::inRandomOrder()->take(5)->get();
+        $tags = Tag::inRandomOrder()->take(8)->get();
 
         return view('posts.index', compact('posts', 'user', 'tags'));
     }

--- a/app/Http/Controllers/PostController.php
+++ b/app/Http/Controllers/PostController.php
@@ -36,7 +36,9 @@ class PostController extends Controller
 
         $user = Auth::user();
 
-        return view('posts.index', compact('posts', 'user'));
+        $tags = Tag::inRandomOrder()->take(5)->get();
+
+        return view('posts.index', compact('posts', 'user', 'tags'));
     }
 
     /**

--- a/public/css/app.css
+++ b/public/css/app.css
@@ -11235,7 +11235,7 @@ input[name=tab_item] {
   display: flex;
 }
 
-.tags__link {
+.tags__link01 {
   box-sizing: border-box;
   text-decoration: none;
   display: flex;
@@ -11245,11 +11245,87 @@ input[name=tab_item] {
   padding-right: 24px;
   padding-left: 24px;
   color: white;
-  background-color: #7e99c8;
   margin-right: 10px;
+  background-color: #7e99c8;
 }
 
-.tags__link:hover {
+.tags__link01:hover {
+  text-decoration: none;
+  color: white;
+}
+
+.tags__link02 {
+  box-sizing: border-box;
+  text-decoration: none;
+  display: flex;
+  align-items: center;
+  border-radius: 4px;
+  height: 40px;
+  padding-right: 24px;
+  padding-left: 24px;
+  color: white;
+  margin-right: 10px;
+  background-color: #c87eb7;
+}
+
+.tags__link02:hover {
+  text-decoration: none;
+  color: white;
+}
+
+.tags__link03 {
+  box-sizing: border-box;
+  text-decoration: none;
+  display: flex;
+  align-items: center;
+  border-radius: 4px;
+  height: 40px;
+  padding-right: 24px;
+  padding-left: 24px;
+  color: white;
+  margin-right: 10px;
+  background-color: #7ec897;
+}
+
+.tags__link03:hover {
+  text-decoration: none;
+  color: white;
+}
+
+.tags__link04 {
+  box-sizing: border-box;
+  text-decoration: none;
+  display: flex;
+  align-items: center;
+  border-radius: 4px;
+  height: 40px;
+  padding-right: 24px;
+  padding-left: 24px;
+  color: white;
+  margin-right: 10px;
+  background-color: #c8ba7e;
+}
+
+.tags__link04:hover {
+  text-decoration: none;
+  color: white;
+}
+
+.tags__link05 {
+  box-sizing: border-box;
+  text-decoration: none;
+  display: flex;
+  align-items: center;
+  border-radius: 4px;
+  height: 40px;
+  padding-right: 24px;
+  padding-left: 24px;
+  color: white;
+  margin-right: 10px;
+  background-color: #927ec8;
+}
+
+.tags__link05:hover {
   text-decoration: none;
   color: white;
 }

--- a/public/css/app.css
+++ b/public/css/app.css
@@ -11330,3 +11330,60 @@ input[name=tab_item] {
   color: white;
 }
 
+.tags__link06 {
+  box-sizing: border-box;
+  text-decoration: none;
+  display: flex;
+  align-items: center;
+  border-radius: 4px;
+  height: 40px;
+  padding-right: 24px;
+  padding-left: 24px;
+  color: white;
+  margin-right: 10px;
+  background-color: #aec87e;
+}
+
+.tags__link06:hover {
+  text-decoration: none;
+  color: white;
+}
+
+.tags__link07 {
+  box-sizing: border-box;
+  text-decoration: none;
+  display: flex;
+  align-items: center;
+  border-radius: 4px;
+  height: 40px;
+  padding-right: 24px;
+  padding-left: 24px;
+  color: white;
+  margin-right: 10px;
+  background-color: #c87e8a;
+}
+
+.tags__link07:hover {
+  text-decoration: none;
+  color: white;
+}
+
+.tags__link08 {
+  box-sizing: border-box;
+  text-decoration: none;
+  display: flex;
+  align-items: center;
+  border-radius: 4px;
+  height: 40px;
+  padding-right: 24px;
+  padding-left: 24px;
+  color: white;
+  margin-right: 10px;
+  background-color: #c8a17e;
+}
+
+.tags__link08:hover {
+  text-decoration: none;
+  color: white;
+}
+

--- a/public/css/app.css
+++ b/public/css/app.css
@@ -11223,7 +11223,7 @@ input[name=tab_item] {
 }
 
 .tags__padding {
-  padding-top: 16px;
+  padding-top: 12px;
   padding-bottom: 16px;
 }
 

--- a/public/css/app.css
+++ b/public/css/app.css
@@ -11218,3 +11218,39 @@ input[name=tab_item] {
   margin: 10px 0 0 auto;
 }
 
+.tags__overflow {
+  overflow-x: auto;
+}
+
+.tags__padding {
+  padding-top: 16px;
+  padding-bottom: 16px;
+}
+
+.tags__display {
+  display: inline-flex;
+}
+
+.tags__flex {
+  display: flex;
+}
+
+.tags__link {
+  box-sizing: border-box;
+  text-decoration: none;
+  display: flex;
+  align-items: center;
+  border-radius: 4px;
+  height: 40px;
+  padding-right: 24px;
+  padding-left: 24px;
+  color: white;
+  background-color: #7e99c8;
+  margin-right: 10px;
+}
+
+.tags__link:hover {
+  text-decoration: none;
+  color: white;
+}
+

--- a/public/css/app.css
+++ b/public/css/app.css
@@ -11220,6 +11220,7 @@ input[name=tab_item] {
 
 .tags__overflow {
   overflow-x: auto;
+  white-space: nowrap;
 }
 
 .tags__padding {

--- a/public/js/app.js
+++ b/public/js/app.js
@@ -37375,7 +37375,7 @@ $(function () {
 /***/ (function(module, exports) {
 
 //付与したいクラスの配列
-var arr = ["tags__link01", "tags__link02", "tags__link03", "tags__link04", "tags__link05"];
+var arr = ["tags__link01", "tags__link02", "tags__link03", "tags__link04", "tags__link05", "tags__link06", "tags__link07", "tags__link08"];
 var a = arr.length; //シャッフルアルゴリズム
 
 while (a) {

--- a/public/js/app.js
+++ b/public/js/app.js
@@ -37367,6 +37367,31 @@ $(function () {
 
 /***/ }),
 
+/***/ "./resources/js/assets/tags-color.js":
+/*!*******************************************!*\
+  !*** ./resources/js/assets/tags-color.js ***!
+  \*******************************************/
+/*! no static exports found */
+/***/ (function(module, exports) {
+
+//付与したいクラスの配列
+var arr = ["tags__link01", "tags__link02", "tags__link03", "tags__link04", "tags__link05"];
+var a = arr.length; //シャッフルアルゴリズム
+
+while (a) {
+  var j = Math.floor(Math.random() * a);
+  var t = arr[--a];
+  arr[a] = arr[j];
+  arr[j] = t;
+} //シャッフルされた配列の要素を順番に表示する
+
+
+arr.forEach(function (value, index) {
+  $(".tags__link").eq(index).addClass(value);
+});
+
+/***/ }),
+
 /***/ "./resources/js/bootstrap.js":
 /*!***********************************!*\
   !*** ./resources/js/bootstrap.js ***!
@@ -37424,15 +37449,16 @@ window.axios.defaults.headers.common['X-Requested-With'] = 'XMLHttpRequest';
 /***/ }),
 
 /***/ 0:
-/*!***************************************************************************************************************************************!*\
-  !*** multi ./resources/js/app.js ./resources/js/assets/input_file.js ./resources/js/assets/request_form.js ./resources/sass/app.scss ***!
-  \***************************************************************************************************************************************/
+/*!***************************************************************************************************************************************************************************!*\
+  !*** multi ./resources/js/app.js ./resources/js/assets/input_file.js ./resources/js/assets/request_form.js ./resources/js/assets/tags-color.js ./resources/sass/app.scss ***!
+  \***************************************************************************************************************************************************************************/
 /*! no static exports found */
 /***/ (function(module, exports, __webpack_require__) {
 
 __webpack_require__(/*! /Applications/MAMP/htdocs/illust_station/resources/js/app.js */"./resources/js/app.js");
 __webpack_require__(/*! /Applications/MAMP/htdocs/illust_station/resources/js/assets/input_file.js */"./resources/js/assets/input_file.js");
 __webpack_require__(/*! /Applications/MAMP/htdocs/illust_station/resources/js/assets/request_form.js */"./resources/js/assets/request_form.js");
+__webpack_require__(/*! /Applications/MAMP/htdocs/illust_station/resources/js/assets/tags-color.js */"./resources/js/assets/tags-color.js");
 module.exports = __webpack_require__(/*! /Applications/MAMP/htdocs/illust_station/resources/sass/app.scss */"./resources/sass/app.scss");
 
 

--- a/resources/js/assets/tags-color.js
+++ b/resources/js/assets/tags-color.js
@@ -1,0 +1,16 @@
+//付与したいクラスの配列
+var arr = ["tags__link01", "tags__link02", "tags__link03", "tags__link04", "tags__link05"];
+var a = arr.length;
+
+//シャッフルアルゴリズム
+while (a) {
+  var j = Math.floor(Math.random() * a);
+  var t = arr[--a];
+  arr[a] = arr[j];
+  arr[j] = t;
+}
+
+//シャッフルされた配列の要素を順番に表示する
+arr.forEach(function (value, index) {
+  $(".tags__link").eq(index).addClass(value);
+});

--- a/resources/js/assets/tags-color.js
+++ b/resources/js/assets/tags-color.js
@@ -1,5 +1,5 @@
 //付与したいクラスの配列
-var arr = ["tags__link01", "tags__link02", "tags__link03", "tags__link04", "tags__link05"];
+var arr = ["tags__link01", "tags__link02", "tags__link03", "tags__link04", "tags__link05", "tags__link06", "tags__link07", "tags__link08"];
 var a = arr.length;
 
 //シャッフルアルゴリズム

--- a/resources/sass/app.scss
+++ b/resources/sass/app.scss
@@ -22,3 +22,5 @@
 @import 'request_messages/message_tab';
 
 @import 'request_messages/request_messages';
+
+@import 'posts/tags';

--- a/resources/sass/app.scss
+++ b/resources/sass/app.scss
@@ -7,6 +7,8 @@
 // Bootstrap
 @import '~bootstrap/scss/bootstrap';
 
+@import 'mixin/tag-button';
+
 @import 'posts/input_type_image.scss';
 
 @import 'button';

--- a/resources/sass/mixin/_tag-button.scss
+++ b/resources/sass/mixin/_tag-button.scss
@@ -1,0 +1,17 @@
+@mixin tag-button {
+  box-sizing: border-box;
+  text-decoration: none;
+  display: flex;
+  -webkit-box-align: center;
+  align-items: center;
+  border-radius: 4px;
+  height: 40px;
+  padding-right: 24px;
+  padding-left: 24px;
+  color: rgb(255, 255, 255);
+  margin-right: 10px;
+  &:hover {
+    text-decoration: none;
+    color: white;
+  }
+}

--- a/resources/sass/posts/_tags.scss
+++ b/resources/sass/posts/_tags.scss
@@ -3,7 +3,7 @@
     overflow-x: auto;
   }
   &__padding {
-    padding-top: 16px;
+    padding-top: 12px;
     padding-bottom: 16px;
   }
   &__display {
@@ -12,22 +12,24 @@
   &__flex {
     display: flex;
   }
-  &__link {
-    box-sizing: border-box;
-    text-decoration: none;
-    display: flex;
-    -webkit-box-align: center;
-    align-items: center;
-    border-radius: 4px;
-    height: 40px;
-    padding-right: 24px;
-    padding-left: 24px;
-    color: rgb(255, 255, 255);
+  &__link01 {
+    @include tag-button;
     background-color: rgb(126, 153, 200);
-    margin-right: 10px;
-    &:hover {
-      text-decoration: none;
-      color: white;
-    }
+  }
+  &__link02 {
+    @include tag-button;
+    background-color: rgb(200, 126, 183);
+  }
+  &__link03 {
+    @include tag-button;
+    background-color: rgb(126, 200, 151);
+  }
+  &__link04 {
+    @include tag-button;
+    background-color: rgb(200, 186, 126);
+  }
+  &__link05 {
+    @include tag-button;
+    background-color: rgb(146, 126, 200);
   }
 }

--- a/resources/sass/posts/_tags.scss
+++ b/resources/sass/posts/_tags.scss
@@ -1,0 +1,33 @@
+.tags {
+  &__overflow {
+    overflow-x: auto;
+  }
+  &__padding {
+    padding-top: 16px;
+    padding-bottom: 16px;
+  }
+  &__display {
+    display: inline-flex;
+  }
+  &__flex {
+    display: flex;
+  }
+  &__link {
+    box-sizing: border-box;
+    text-decoration: none;
+    display: flex;
+    -webkit-box-align: center;
+    align-items: center;
+    border-radius: 4px;
+    height: 40px;
+    padding-right: 24px;
+    padding-left: 24px;
+    color: rgb(255, 255, 255);
+    background-color: rgb(126, 153, 200);
+    margin-right: 10px;
+    &:hover {
+      text-decoration: none;
+      color: white;
+    }
+  }
+}

--- a/resources/sass/posts/_tags.scss
+++ b/resources/sass/posts/_tags.scss
@@ -1,6 +1,7 @@
 .tags {
   &__overflow {
     overflow-x: auto;
+    white-space: nowrap;
   }
   &__padding {
     padding-top: 12px;

--- a/resources/sass/posts/_tags.scss
+++ b/resources/sass/posts/_tags.scss
@@ -32,4 +32,16 @@
     @include tag-button;
     background-color: rgb(146, 126, 200);
   }
+  &__link06 {
+    @include tag-button;
+    background-color: rgb(174, 200, 126);
+  }
+  &__link07 {
+    @include tag-button;
+    background-color: rgb(200, 126, 138);
+  }
+  &__link08 {
+    @include tag-button;
+    background-color: rgb(200, 161, 126);
+  }
 }

--- a/resources/views/posts/index.blade.php
+++ b/resources/views/posts/index.blade.php
@@ -9,9 +9,11 @@
             <div class="tags">
                 <div class="tags__overflow">
                     <div class="tags__padding">
-                        <div class="tags_display">
+                        <div class="tags__display">
                             @foreach($tags as $tag)
-                                <div class="tags__flex">{{ $tag->name }}</div>
+                                <div class="tags__flex">
+                                    <a class="tags__link" href="">#{{ $tag->name }}</a>
+                                </div>
                             @endforeach
                         </div>
                     </div>

--- a/resources/views/posts/index.blade.php
+++ b/resources/views/posts/index.blade.php
@@ -12,7 +12,7 @@
                         <div class="tags__display">
                             @foreach($tags as $tag)
                                 <div class="tags__flex">
-                                    <a class="tags__link" href="">#{{ $tag->name }}</a>
+                                    <a class="tags__link" href="{{ route('tags.show', ['id' => $tag->id]) }}">#{{ $tag->name }}</a>
                                 </div>
                             @endforeach
                         </div>

--- a/resources/views/posts/index.blade.php
+++ b/resources/views/posts/index.blade.php
@@ -1,9 +1,22 @@
 @extends('layouts.app')
 
 @section('content')
+
 <div class="container">
+    
     <div class="row justify-content-center">
         <div class="col-md-12">
+            <div class="tags">
+                <div class="tags__overflow">
+                    <div class="tags__padding">
+                        <div class="tags_display">
+                            @foreach($tags as $tag)
+                                <div class="tags__flex">{{ $tag->name }}</div>
+                            @endforeach
+                        </div>
+                    </div>
+                </div>
+            </div>
             <div class="card">
 
                 <div class="card-body">

--- a/webpack.mix.js
+++ b/webpack.mix.js
@@ -18,5 +18,6 @@ mix.js([
     'resources/js/app.js',
     'resources/js/assets/input_file.js',
     'resources/js/assets/request_form.js',
+    'resources/js/assets/tags-color.js',
     ], 'public/js/app.js')
    .sass('resources/sass/app.scss', 'public/css');


### PR DESCRIPTION
# What
トップページにタグをランダムに表示する
- コントローラーにtagsテーブルからランダムにタグを取得する処理を記述。
- foreachを用いてトップページに取得したタグを表示する。
- タグにそのタグに紐付けされた投稿の一覧ページのリンクを設定する。
- scssを用いてタグのデザインをする。
- jsを用いてforeachで表示されている要素にランダムにscssを当てることでタグを異なる背景色にする。
- タグが枠からはみ出た場合は、overflow-x: autoを用いて横にスクロールできるようにする。

# Why
- ユーザーが興味のあるタグを見つけることで新しい発見があるため。
- サイトの印象を明るく楽しいものにするため。

<img width="1310" alt="045b2daf8d15271278bb0d41af75b477" src="https://user-images.githubusercontent.com/52768993/124350016-117d5e80-dc2d-11eb-9b4d-26a83feeb9ca.png">