### PR TITLE
Add:【サーバーサイド】リクエストFormにバリデーションを追加

### DIFF
--- a/app/Http/Controllers/Request_messageController.php
+++ b/app/Http/Controllers/Request_messageController.php
@@ -19,7 +19,7 @@ class Request_messageController extends Controller
         return view('request_messages.index', compact('users', 'requestsFromUser', 'requestsToUser'));
     }
 
-    public function store(Request $request)
+    public function store(Request_messageRequest $request)
     {
         $post_id = $request->post_id;
 

--- a/app/Http/Controllers/Request_messageController.php
+++ b/app/Http/Controllers/Request_messageController.php
@@ -5,6 +5,7 @@ namespace App\Http\Controllers;
 use Illuminate\Http\Request;
 use App\User;
 use App\Models\Request_message;
+use App\Http\Requests\Request_messageRequest;
 
 class Request_messageController extends Controller
 {

--- a/app/Http/Requests/Request_messageRequest.php
+++ b/app/Http/Requests/Request_messageRequest.php
@@ -24,7 +24,8 @@ class Request_messageRequest extends FormRequest
     public function rules()
     {
         return [
-            //
+            'title' => 'required|string',
+            'body' => 'required|string',
         ];
     }
 }

--- a/app/Http/Requests/Request_messageRequest.php
+++ b/app/Http/Requests/Request_messageRequest.php
@@ -13,7 +13,7 @@ class Request_messageRequest extends FormRequest
      */
     public function authorize()
     {
-        return false;
+        return true;
     }
 
     /**

--- a/app/Http/Requests/Request_messageRequest.php
+++ b/app/Http/Requests/Request_messageRequest.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class Request_messageRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     *
+     * @return bool
+     */
+    public function authorize()
+    {
+        return false;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array
+     */
+    public function rules()
+    {
+        return [
+            //
+        ];
+    }
+}

--- a/resources/lang/ja/validation.php
+++ b/resources/lang/ja/validation.php
@@ -122,6 +122,7 @@ return [
         'content' => '内容',
         'image' => '画像',
         'comment' => 'コメント',
+        'body' => 'リクエスト',
     ],
 
 ];

--- a/resources/views/posts/show.blade.php
+++ b/resources/views/posts/show.blade.php
@@ -68,10 +68,10 @@
                                     @include('comments.comment')
                                 @endforeach
                             </div>
-                            @if ($errors->any())
+                            @if ($errors->has('comment'))
                                 <div class="alert alert-danger mt-3">
                                     <ul class="mb-0">
-                                        @foreach ($errors->all() as $error)
+                                        @foreach ($errors->get('comment') as $error)
                                             <li>{{ $error }}</li>
                                         @endforeach
                                     </ul>
@@ -96,10 +96,10 @@
                                     {{ $post->user->name}}さんへのリクエスト
                                 </div>
                             </div>
-                            @if ($errors->any())
+                            @if ($errors->has('title'))
                                 <div class="alert alert-danger mt-3">
                                     <ul class="mb-0">
-                                        @foreach ($errors->all() as $error)
+                                        @foreach ($errors->get('title') as $error)
                                             <li>{{ $error }}</li>
                                         @endforeach
                                     </ul>
@@ -112,6 +112,15 @@
                                 <input type="hidden" name="post_id"  value="{{ $post->id }}">
                                 <div class="request__submit-area mt-3">
                                     <input type="text" name="title" class="form-control" placeholder="タイトルを入力">
+                                    @if ($errors->has('body'))
+                                        <div class="alert alert-danger mt-3">
+                                            <ul class="mb-0">
+                                                @foreach ($errors->get('body') as $error)
+                                                    <li>{{ $error }}</li>
+                                                @endforeach
+                                            </ul>
+                                        </div>
+                                    @endif
                                     <textarea name="body" class="form-control request__textarea mt-2" placeholder="描いてほしいテーマやキャラクターの特徴を伝えましょう。" aria-label="With textarea"></textarea>
                                     <button type="input-group-prepend button submit" class="btn btn-outline-primary request__button">リクエストを送る</button>
                                 </div>


### PR DESCRIPTION
# What
リクエストフォームにバリデーションが効くように設定した。
- フォームリクエストクラスを用いて投稿へのコメントをする際にバリデーションが効くようにする
- title及びbodyカラムに対してrequired（必須）、string（文字列）でないとコメントが弾かれるようにした。
- comment、title、bodyそれぞれ項目ごとにバリデーションが表示されるように修正した。

# Why
- 不適切なエラーを表示できないようにするため。
- 処理が適切にできていないことをユーザーに伝えるため。
