### PR TITLE
Edit【マークアップ】プロフィールページのデザインを修正

### DIFF
--- a/public/css/app.css
+++ b/public/css/app.css
@@ -11415,6 +11415,69 @@ input[name=tab_item] {
   background-color: #fff;
 }
 
+.profile__header {
+  position: -webkit-sticky;
+  position: sticky;
+  bottom: 0px;
+  margin: 0px auto;
+  padding-right: 72px;
+  padding-left: 72px;
+  display: flex;
+}
+
+.profile__left {
+  margin-right: 24px;
+  margin-top: -24px;
+}
+
+.profile__image {
+  display: block;
+  border-radius: 50%;
+  flex: 0 0 auto;
+  overflow: hidden;
+  width: 96px;
+  height: 96px;
+  border: 2px solid white;
+  margin: -2px;
+  position: relative;
+}
+
+.profile__right {
+  padding-top: 24px;
+  padding-bottom: 24px;
+  flex: 1 1 0%;
+  display: flex;
+}
+
+.profile__username {
+  font-size: 20px;
+  line-height: 28px;
+  font-weight: bold;
+  display: flow-root;
+  color: rgba(0, 0, 0, 0.88);
+  margin: 0px;
+}
+
+.profile__edit {
+  margin-left: auto;
+}
+
+.profile__edit-a-tag {
+  background-color: #f5f5f5;
+  padding: 9px 24px;
+  line-height: 22px;
+  border: none;
+  border-radius: 100vw;
+  font-size: 14px;
+  font-weight: 700;
+  background-color: #fff;
+  transition: background-color 0.2s;
+  color: #666;
+  cursor: pointer;
+  text-align: center;
+  text-decoration: none;
+}
+
 /*!
  * Font Awesome Free 5.15.3 by @fontawesome - https://fontawesome.com
  * License - https://fontawesome.com/license/free (Icons: CC BY 4.0, Fonts: SIL OFL 1.1, Code: MIT License)

--- a/public/css/app.css
+++ b/public/css/app.css
@@ -11481,6 +11481,76 @@ input[name=tab_item] {
   text-decoration: none;
 }
 
+.profile__main {
+  padding: 0px 0px 0px;
+  min-height: 5vh;
+  margin-top: 40px;
+}
+
+.profile__links {
+  display: flex;
+}
+
+.profile__form {
+  margin-left: auto;
+}
+
+.profile__a-tag {
+  padding: 0.1em 0.3em;
+  position: relative;
+  display: inline-block;
+  transition: 0.3s;
+  color: #2196f4;
+}
+
+.profile__a-tag::after {
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  content: "";
+  width: 0;
+  height: 1px;
+  background-color: #2196f4;
+  transition: 0.3s;
+}
+
+.profile__a-tag:hover::after {
+  width: 100%;
+}
+
+.profile__a-tag:hover {
+  text-decoration: none;
+  color: #2196f4;
+}
+
+.profile__delete {
+  padding: 0.1em 0.3em;
+  position: relative;
+  display: inline-block;
+  transition: 0.3s;
+  color: #EC407A;
+}
+
+.profile__delete::after {
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  content: "";
+  width: 0;
+  height: 1px;
+  background-color: #EC407A;
+  transition: 0.3s;
+}
+
+.profile__delete:hover::after {
+  width: 100%;
+}
+
+.profile__delete:hover {
+  text-decoration: none;
+  color: #EC407A;
+}
+
 /*!
  * Font Awesome Free 5.15.3 by @fontawesome - https://fontawesome.com
  * License - https://fontawesome.com/license/free (Icons: CC BY 4.0, Fonts: SIL OFL 1.1, Code: MIT License)

--- a/public/css/app.css
+++ b/public/css/app.css
@@ -11411,6 +11411,10 @@ input[name=tab_item] {
   -ms-transform: translateX(-50%);
 }
 
+.profile {
+  background-color: #fff;
+}
+
 /*!
  * Font Awesome Free 5.15.3 by @fontawesome - https://fontawesome.com
  * License - https://fontawesome.com/license/free (Icons: CC BY 4.0, Fonts: SIL OFL 1.1, Code: MIT License)

--- a/public/css/app.css
+++ b/public/css/app.css
@@ -11420,8 +11420,6 @@ input[name=tab_item] {
   position: sticky;
   bottom: 0px;
   margin: 0px auto;
-  padding-right: 72px;
-  padding-left: 72px;
   display: flex;
 }
 

--- a/public/css/app.css
+++ b/public/css/app.css
@@ -11470,11 +11470,16 @@ input[name=tab_item] {
   border-radius: 100vw;
   font-size: 14px;
   font-weight: 700;
-  background-color: #fff;
   transition: background-color 0.2s;
   color: #666;
   cursor: pointer;
   text-align: center;
+  text-decoration: none;
+}
+
+.profile__edit-a-tag:hover {
+  background-color: #dcdcdc;
+  color: #666;
   text-decoration: none;
 }
 

--- a/resources/sass/app.scss
+++ b/resources/sass/app.scss
@@ -29,6 +29,8 @@
 
 @import 'flash_message';
 
+@import 'users/profile';
+
 @import '~@fortawesome/fontawesome-free/scss/fontawesome';
 @import '~@fortawesome/fontawesome-free/scss/solid';
 @import '~@fortawesome/fontawesome-free/scss/regular';

--- a/resources/sass/users/_profile.scss
+++ b/resources/sass/users/_profile.scss
@@ -1,0 +1,3 @@
+.profile {
+  background-color: #fff;
+}

--- a/resources/sass/users/_profile.scss
+++ b/resources/sass/users/_profile.scss
@@ -1,3 +1,70 @@
 .profile {
   background-color: #fff;
+  &__header {
+    position: sticky;
+    bottom: 0px;
+    margin: 0px auto;
+    padding-right: 72px;
+    padding-left: 72px;
+    display: flex;
+  }
+  &__left {
+    margin-right: 24px;
+    margin-top: -24px;
+  }
+  &__image {
+    display: block;
+    border-radius: 50%;
+    flex: 0 0 auto;
+    overflow: hidden;
+    width: 96px;
+    height: 96px;
+    border: 2px solid rgb(255, 255, 255);
+    margin: -2px;
+    position: relative;
+  }
+  &__right {
+    padding-top: 24px;
+    padding-bottom: 24px;
+    flex: 1 1 0%;
+    display: flex;
+  }
+  &__grid {
+    // display: grid;
+    // grid-template-columns: 1fr auto;
+  }
+  &__username {
+    font-size: 20px;
+    line-height: 28px;
+    font-weight: bold;
+    display: flow-root;
+    color: rgba(0, 0, 0, 0.88);
+    margin: 0px;
+  }
+  &__edit {
+    margin-left: auto;
+
+  }
+  &__edit-a-tag {
+    background-color: #f5f5f5;
+    padding: 9px 24px;
+    line-height: 22px;
+    border: none;
+    border-radius: 100vw;
+    font-size: 14px;
+    font-weight: 700;
+    background-color: #fff;
+    -webkit-transition: background-color .2s;
+    transition: background-color .2s;
+    color: #666;
+    cursor: pointer;
+    text-align: center;
+    text-decoration: none;
+  }
+  &__main {
+
+  }
+  &__request {
+
+  }
 }

--- a/resources/sass/users/_profile.scss
+++ b/resources/sass/users/_profile.scss
@@ -27,10 +27,6 @@
     flex: 1 1 0%;
     display: flex;
   }
-  &__grid {
-    // display: grid;
-    // grid-template-columns: 1fr auto;
-  }
   &__username {
     font-size: 20px;
     line-height: 28px;
@@ -41,7 +37,6 @@
   }
   &__edit {
     margin-left: auto;
-
   }
   &__edit-a-tag {
     background-color: #f5f5f5;
@@ -71,12 +66,6 @@
   }
   &__links {
     display: flex;
-  }
-  &__link {
-
-  }
-  &__request {
-
   }
   &__form {
     margin-left: auto;

--- a/resources/sass/users/_profile.scss
+++ b/resources/sass/users/_profile.scss
@@ -53,13 +53,18 @@
     border-radius: 100vw;
     font-size: 14px;
     font-weight: 700;
-    background-color: #fff;
+    // background-color: #fff;
     -webkit-transition: background-color .2s;
     transition: background-color .2s;
     color: #666;
     cursor: pointer;
     text-align: center;
     text-decoration: none;
+    &:hover {
+      background-color: #dcdcdc;
+      color: #666;
+      text-decoration: none;
+    }
   }
   &__main {
 

--- a/resources/sass/users/_profile.scss
+++ b/resources/sass/users/_profile.scss
@@ -65,9 +65,68 @@
     }
   }
   &__main {
+    padding: 0px 0px 0px;
+    min-height: 5vh;
+    margin-top: 40px;
+  }
+  &__links {
+    display: flex;
+  }
+  &__link {
 
   }
   &__request {
 
+  }
+  &__form {
+    margin-left: auto;
+  }
+  &__a-tag {
+    padding: 0.1em 0.3em;
+    position: relative;
+    display: inline-block;
+    transition: .3s;
+    color: #2196f4;
+    &::after {
+      position: absolute;
+      bottom: 0;
+      left: 0;
+      content: '';
+      width: 0;
+      height: 1px;
+      background-color: #2196f4;
+      transition: .3s;
+    }
+    &:hover::after {
+      width: 100%;
+    }
+    &:hover {
+      text-decoration: none;
+      color: #2196f4;
+    }
+  }
+  &__delete {
+    padding: 0.1em 0.3em;
+    position: relative;
+    display: inline-block;
+    transition: .3s;
+    color: #EC407A;
+    &::after {
+      position: absolute;
+      bottom: 0;
+      left: 0;
+      content: '';
+      width: 0;
+      height: 1px;
+      background-color: #EC407A;
+      transition: .3s;
+    }
+    &:hover::after {
+      width: 100%;
+    }
+    &:hover {
+      text-decoration: none;
+      color: #EC407A;
+    }
   }
 }

--- a/resources/sass/users/_profile.scss
+++ b/resources/sass/users/_profile.scss
@@ -4,8 +4,6 @@
     position: sticky;
     bottom: 0px;
     margin: 0px auto;
-    padding-right: 72px;
-    padding-left: 72px;
     display: flex;
   }
   &__left {

--- a/resources/views/users/show.blade.php
+++ b/resources/views/users/show.blade.php
@@ -3,8 +3,30 @@
 @section('content')
 
 <div class="container m-5">
+    <div class="row justify-content-center">
+        <div class="col-md-8 profile">
+            <div class="profile__header">
+                <div class="profile__left">
+                    <div class="profile__image">
+                    </div>
+                </div>
+                <div class="profile__right">
+                    <div class="profile__username">
+                    </div>
+                    <div class="profile__edit">
+                    </div>
+                </div>
+            </div>
+            <div class="profile__main">
+                <div class="profile__request"></div>
+            </div>
+        </div>
+    </div>
+</div>
+
+<div class="container m-5">
   <div class="row justify-content-center">
-    <div class="col-md-8">
+    <div class="col-md-8 profile">
       <div class="card">
         <div class="card-header">ユーザー登録内容</div>
         <div class="card-body">

--- a/resources/views/users/show.blade.php
+++ b/resources/views/users/show.blade.php
@@ -42,41 +42,6 @@
     </div>
 </div>
 
-<!-- <div class="container m-5">
-  <div class="row justify-content-center">
-    <div class="col-md-8">
-      <div class="card">
-        <div class="card-header">ユーザー登録内容</div>
-        <div class="card-body">
-            <div class="form-group">
-                <span>名前：</span>
-                <span>{{ $user->name }}</span>
-            </div>
-            <div class="form-group">
-                <span>メールアドレス：</span>
-                <span>{{ $user->email }}</span>
-            </div>
-              <div>
-                <a href="{{ route('request_messages.index')}}">
-                  <button class="btn btn-primary">リクエストを確認する</button>
-                </a>
-              </div>
-              <div class="mt-3">
-                <a href="{{ route('users.edit', [$user->id])}}">
-                  <button class="btn btn-primary">ユーザー登録内容の編集する</button>
-                </a>
-              </div>
-                <form method="POST" action="{{ route('users.destroy', [$user->id])}}" id="delete_{{ $user->id}}">
-                  @csrf
-                  <br>
-                  <a href="#" class="btn btn-outline-danger" data-id="{{ $user->id }}" onclick="deletePost(this); ">アカウントを削除する</a>
-                </form>
-        </div>
-      </div>
-    </div>
-  </div>
-</div> -->
-
 <script>
 function deletePost(e) {
   'use strict';

--- a/resources/views/users/show.blade.php
+++ b/resources/views/users/show.blade.php
@@ -8,12 +8,17 @@
             <div class="profile__header">
                 <div class="profile__left">
                     <div class="profile__image">
+                        <img src="https://illust-station-takiterina-bucket.s3-ap-northeast-1.amazonaws.com/3h0TDmfZqpp7d2D1nM2dhc5Lus4QSnodVCMVn3r5.png" width="100" height="100" class="img-fluid" alt="ロゴ">
                     </div>
                 </div>
                 <div class="profile__right">
                     <div class="profile__username">
+                        {{ $user->name }}
                     </div>
                     <div class="profile__edit">
+                        <a href="{{ route('users.edit', [$user->id])}}" class="profile__edit-a-tag">
+                            プロフィールを編集
+                        </a>
                     </div>
                 </div>
             </div>

--- a/resources/views/users/show.blade.php
+++ b/resources/views/users/show.blade.php
@@ -2,7 +2,7 @@
 
 @section('content')
 
-<div class="container m-5">
+<div class="container mt-5">
     <div class="row justify-content-center">
         <div class="col-md-8 profile">
             <div class="profile__header">

--- a/resources/views/users/show.blade.php
+++ b/resources/views/users/show.blade.php
@@ -8,7 +8,7 @@
             <div class="profile__header">
                 <div class="profile__left">
                     <div class="profile__image">
-                        <img src="https://illust-station-takiterina-bucket.s3-ap-northeast-1.amazonaws.com/3h0TDmfZqpp7d2D1nM2dhc5Lus4QSnodVCMVn3r5.png" width="100" height="100" class="img-fluid" alt="ロゴ">
+                        <img src="https://illust-station-takiterina-bucket.s3-ap-northeast-1.amazonaws.com/user-icon-silhouette.png" width="100" height="100" class="img-fluid" alt="ロゴ">
                     </div>
                 </div>
                 <div class="profile__right">

--- a/resources/views/users/show.blade.php
+++ b/resources/views/users/show.blade.php
@@ -23,13 +23,26 @@
                 </div>
             </div>
             <div class="profile__main">
-                <div class="profile__request"></div>
+                <div class="profile__links">
+                    <div class="profile__request profile__link">
+                        <a href="{{ route('request_messages.index')}}" class="profile__a-tag">リクエスト</a>
+                    </div>
+                    <div class="profile__request profile__link">
+                        <a href="#" class="profile__a-tag">作品一覧</a>
+                    </div>
+                    <form method="POST" action="{{ route('users.destroy', [$user->id])}}" id="delete_{{ $user->id}}"class="profile__form">
+                        @csrf
+                        <div class="profile__link">
+                            <a href="#" class="profile__a-tag profile__delete" data-id="{{ $user->id }}" onclick="deletePost(this); ">アカウントを削除する</a>
+                        </div>
+                    </form>
+                </div>
             </div>
         </div>
     </div>
 </div>
 
-<div class="container m-5">
+<!-- <div class="container m-5">
   <div class="row justify-content-center">
     <div class="col-md-8">
       <div class="card">
@@ -62,7 +75,7 @@
       </div>
     </div>
   </div>
-</div>
+</div> -->
 
 <script>
 function deletePost(e) {

--- a/resources/views/users/show.blade.php
+++ b/resources/views/users/show.blade.php
@@ -31,7 +31,7 @@
 
 <div class="container m-5">
   <div class="row justify-content-center">
-    <div class="col-md-8 profile">
+    <div class="col-md-8">
       <div class="card">
         <div class="card-header">ユーザー登録内容</div>
         <div class="card-body">


### PR DESCRIPTION
# What
プロフィールページのデザインを修正する。
- ユーザーのアイコンを表示する枠を作成する（現状は共通シルエット、今後アップロード機能実装予定）。
- プロフィール変更、リクエスト及び作品一覧のリンク、及びアカウント削除ボタンのデザイン及び配置を修正する。

# Why
元々bootstrapだけで実装できる簡易的なデザインだったのでトップページなどサイト全体のデザインとの統一性を出すためにデザインを変更した。

<img width="1036" alt="1826674420da9f292c57bc072c64a918" src="https://user-images.githubusercontent.com/52768993/126726740-25115392-9683-4842-a92a-2a74a60b56b0.png">
