### PR TITLE
Edit:【README】ffmpegを用いてmp4をgifに変換した

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -48,21 +48,22 @@ illust stationはユーザーが作成したイラストを画像ファイルと
 投稿された画像が一覧で表示されるトップページである。ヘッダーにはログイン及び新規登録ページへのリンクがあり、その下には投稿に紐付けられたタグがランダムで表示される。また、投稿の詳細ページへは表示されている画像を押下すれば遷移する。
 
 ## サインアップ
-![8a7f7452690374ca8a0c87e2b1542056](https://user-images.githubusercontent.com/52768993/127725838-faee19fd-5bc2-4b90-a859-8f0155afc8d1.gif)
+![twitter_signup_function](https://user-images.githubusercontent.com/52768993/127735412-2a75141d-9147-45e7-a9c6-ff822f2e725a.gif)
 必要事項を記入し新規登録が可能である。ツイッターアカウントがログイン状態であればTwitter APIを用いてツイッターアカウントでサインアップ可能である。
 
 ## ログイン
-![84846eed2b323a56b7ef0ad402ebe426](https://user-images.githubusercontent.com/52768993/127726172-4d56b106-9ef6-4856-9d4f-33d363f3b048.gif)
+![login_function](https://user-images.githubusercontent.com/52768993/127735367-3c3a1613-dddc-47cd-8eee-8fbd6837606c.gif)
+![twitter_login_function](https://user-images.githubusercontent.com/52768993/127735398-d5265970-9f4b-4fd2-8ecf-5f117161befc.gif)
 登録したユーザーがログインできる。Twitter APIを用いてログインも可能である。また、パスワードを失念した際は、再設定リンクを登録したアドレスに送信可能である。
 
 ## 投稿詳細ページ
-![273a2cea4d0a220139602ac418a0a7a8](https://user-images.githubusercontent.com/52768993/127726317-38a4aba9-fef2-4a35-93a0-081d8fd07420.gif)
+![post_show_display](https://user-images.githubusercontent.com/52768993/127735384-9c2cf1f6-edac-4e1a-830e-8b00fc2f7cca.gif)
 投稿画像、タイトル、作者、メッセージが閲覧可能である。また、投稿へのコメントフォーム及び作者へのリクエストフォームが配置されている。
 
 ## リクエスト機能
 <img width="728" alt="c857cea4444cec8b0b4da99bcc5f7f57" src="https://user-images.githubusercontent.com/52768993/124951337-366b3a80-e04e-11eb-8e67-55f40900c4c4.png">
 
-![c3d6ad74e40c75a558fec22d61888319](https://user-images.githubusercontent.com/52768993/127726476-63a7ee13-73ba-4705-bf91-8eddbfaec5d9.gif)
+![request_function](https://user-images.githubusercontent.com/52768993/127735389-8e44fc53-0d2a-4943-ab8d-33d1adb67397.gif)
 作者に描いて欲しいイラストの詳細を記述し、作者のマイページへと送信する。
 その後、作者がリクエストに答えてイラストを投稿する。
 


### PR DESCRIPTION
# What
前回のreadme編集でmp4の拡張子を手動でgifに変換したがreadmeでうまく表示されなかったのでgifファイルへの変換を別の方法で行う
- Homebrewでffmpegとimagemagickをインストールする。ターミナルで$ brew install ffmpeg及び$ brew install imagemagickを実行する。
- MP4→pngで細切れにする→gifへ圧縮する
  - 変換用のフォルダを作りそこに変換したい動画を格納
  - 動画を入れているフォルダへ移動
  - 動画を10frames/secでpng作成($ ffmpeg -i 動画のファイル名.mp4 -an -r 10 %04d.png)
  - 作成したpngを40%にリサイズ($ convert *.png -resize 40% output_%04d.png)
  - gifに変換($ convert output_*.png つけたいファイル名.gif)