### PR TITLE
Edit:【マークアップ】投稿詳細ページの修正

### DIFF
--- a/public/css/app.css
+++ b/public/css/app.css
@@ -11388,6 +11388,14 @@ input[name=tab_item] {
   color: white;
 }
 
+.show__text {
+  display: flex;
+}
+
+.show__user {
+  margin-left: 16px;
+}
+
 .flash {
   position: relative;
 }

--- a/resources/sass/app.scss
+++ b/resources/sass/app.scss
@@ -27,6 +27,8 @@
 
 @import 'posts/tags';
 
+@import 'posts/show';
+
 @import 'flash_message';
 
 @import 'users/profile';

--- a/resources/sass/posts/_show.scss
+++ b/resources/sass/posts/_show.scss
@@ -1,0 +1,8 @@
+.show {
+  &__text {
+    display: flex;
+  }
+  &__user {
+    margin-left: 16px;
+  }
+}

--- a/resources/views/posts/show.blade.php
+++ b/resources/views/posts/show.blade.php
@@ -4,132 +4,141 @@
 <div class="container">
     <div class="row justify-content-center">
         <div class="col-md-8">
-            @if (session('status'))
-                <div class="flash" role="alert">
-                    <div class="flash__message">
-                        <i class="far fa-check-square"></i>
-                        {{ session('status') }}
+            <div class="show">
+                @if (session('status'))
+                    <div class="flash" role="alert">
+                        <div class="flash__message">
+                            <i class="far fa-check-square"></i>
+                            {{ session('status') }}
+                        </div>
                     </div>
-                </div>
-            @endif
-            <div class="card">
+                @endif
+                <div class="card">
 
-                <div class="card-body">
+                    <div class="card-body">
 
-                    <div class="alert alert-info font-weight-bold" role="alert">
-                      <span>タイトル：</span>
-                      {{ $post->title}}
-                    </div>
-                    <div class="mb-3">
-                      @if($post->image == null)
-                        <img src="/storage/no-image.png" class="img-responsive d-block mx-auto" style="max-width: 100%; height: auto; width /***/:auto;">
-                      @else
-                        <img src="{{$post->image}}" class="img-responsive d-block mx-auto" style="max-width: 100%; height: auto; width /***/:auto;">
-                      @endif
-                    </div>
-                    
-                    <div class="border-bottom pb-2">
-                    <span class="ml-3" >
-                    <a href="{{ route('users.post_show', ['id' => $post->user->id]) }}">{{ $post->user->name}}</a>
-                    ：</span>{{ $post->content}}</div>
+                        <div class="alert alert-info font-weight-bold" role="alert">
+                        <span>タイトル：</span>
+                        {{ $post->title}}
+                        </div>
+                        <div class="mb-3">
+                        @if($post->image == null)
+                            <img src="/storage/no-image.png" class="img-responsive d-block mx-auto" style="max-width: 100%; height: auto; width /***/:auto;">
+                        @else
+                            <img src="{{$post->image}}" class="img-responsive d-block mx-auto" style="max-width: 100%; height: auto; width /***/:auto;">
+                        @endif
+                        </div>
+                        
+                        <div class="border-bottom pb-2 show__text">
+                            <div class="show__user">
+                                <a href="{{ route('users.post_show', ['id' => $post->user->id]) }}">{{ $post->user->name}}</a>
+                            </div>
+                            <div class="show__content">
+                                ：{{ $post->content}}
+                            </div>
+                            <!-- <span class="ml-3" > -->
+                            
+                            <!-- ：</span> -->
+                        </div>
 
-                    <div class="border-bottom pt-2 pb-2">
-                    <span class="ml-3">投稿日：</span>{{ $post->created_at}}
-                    </div>
+                        <div class="border-bottom pt-2 pb-2">
+                        <span class="ml-3">投稿日：</span>{{ $post->created_at}}
+                        </div>
 
-                    <div class="mt-2">
-                        @foreach($post->tag as $post_tag)
-                            <a href="{{ route('tags.show', ['id' => $post_tag->id]) }}">
-                            <span class="ml-3">#{{$post_tag->name}}</span>
-                            </a>
-                        @endforeach
-                    </div>
-
-                    {{-- 現在ログインしているユーザーの投稿であれば表示する --}}
-
-                    @auth
-                        @if(($post->user_id) === (Auth::user()->id ))
-                            <div class="d-flex mt-3">
-                                <a href="{{ route('posts.edit', ['id' => $post->id])}}">
-                                    <input class="btn btn-primary" type="submit" value="変更する">
+                        <div class="mt-2">
+                            @foreach($post->tag as $post_tag)
+                                <a href="{{ route('tags.show', ['id' => $post_tag->id]) }}">
+                                <span class="ml-3">#{{$post_tag->name}}</span>
                                 </a>
-                                <div class="ml-3">
-                                    <form method="POST" action="{{ route('posts.destroy', ['id' => $post->id])}}" id="delete_{{ $post->id}}">
-                                        @csrf
-                                        <a href="#" class="btn btn-outline-danger" data-id="{{ $post->id }}" onclick="deletePost(this); ">削除する</a>
-                                    </form>
-                                </div>
-                            </div>
-                        @endif
-                        <div class="comment justify-content-center mt-3">
-                            <div class="comment__area">
-                                <div class="font-weight-bold text-center">
-                                    この投稿へのコメント
-                                </div>
-                                @foreach ($post->comment as $comment)
-                                    @include('comments.comment')
-                                @endforeach
-                            </div>
-                            @if ($errors->has('comment'))
-                                <div class="alert alert-danger mt-3">
-                                    <ul class="mb-0">
-                                        @foreach ($errors->get('comment') as $error)
-                                            <li>{{ $error }}</li>
-                                        @endforeach
-                                    </ul>
+                            @endforeach
+                        </div>
+
+                        {{-- 現在ログインしているユーザーの投稿であれば表示する --}}
+
+                        @auth
+                            @if(($post->user_id) === (Auth::user()->id ))
+                                <div class="d-flex mt-3">
+                                    <a href="{{ route('posts.edit', ['id' => $post->id])}}">
+                                        <input class="btn btn-primary" type="submit" value="変更する">
+                                    </a>
+                                    <div class="ml-3">
+                                        <form method="POST" action="{{ route('posts.destroy', ['id' => $post->id])}}" id="delete_{{ $post->id}}">
+                                            @csrf
+                                            <a href="#" class="btn btn-outline-danger" data-id="{{ $post->id }}" onclick="deletePost(this); ">削除する</a>
+                                        </form>
+                                    </div>
                                 </div>
                             @endif
-                            <form method="POST" action="{{route('comments.store')}}">
-                                @csrf
-                                <input type="hidden" name="post_id"  value="{{ $post->id }}">
-                                <div class="comment__submit-area mt-3">
-                                    <textarea id="comment" name="comment" class="form-control comment__textarea" placeholder="コメントする" aria-label="With textarea"></textarea>
-                                    <button type="input-group-prepend button submit" class="btn btn-outline-primary comment__button">コメントする</button>
+                            <div class="comment justify-content-center mt-3">
+                                <div class="comment__area">
+                                    <div class="font-weight-bold text-center">
+                                        この投稿へのコメント
+                                    </div>
+                                    @foreach ($post->comment as $comment)
+                                        @include('comments.comment')
+                                    @endforeach
                                 </div>
-                            </form>
-                        </div>
-                        @if(($post->user_id) !== (Auth::user()->id ))
-                        <div class="request-button">
-                            <button type="button" class="btn font-weight-bold button-design">作者にリクエストする</button>
-                        </div>
-                        <div class="request justify-content-center mt-3" id="request">
-                            <div class="request__area">
-                                <div class="font-weight-bold text-center">
-                                    {{ $post->user->name}}さんへのリクエスト
-                                </div>
+                                @if ($errors->has('comment'))
+                                    <div class="alert alert-danger mt-3">
+                                        <ul class="mb-0">
+                                            @foreach ($errors->get('comment') as $error)
+                                                <li>{{ $error }}</li>
+                                            @endforeach
+                                        </ul>
+                                    </div>
+                                @endif
+                                <form method="POST" action="{{route('comments.store')}}">
+                                    @csrf
+                                    <input type="hidden" name="post_id"  value="{{ $post->id }}">
+                                    <div class="comment__submit-area mt-3">
+                                        <textarea id="comment" name="comment" class="form-control comment__textarea" placeholder="コメントする" aria-label="With textarea"></textarea>
+                                        <button type="input-group-prepend button submit" class="btn btn-outline-primary comment__button">コメントする</button>
+                                    </div>
+                                </form>
                             </div>
-                            @if ($errors->has('title'))
-                                <div class="alert alert-danger mt-3">
-                                    <ul class="mb-0">
-                                        @foreach ($errors->get('title') as $error)
-                                            <li>{{ $error }}</li>
-                                        @endforeach
-                                    </ul>
+                            @if(($post->user_id) !== (Auth::user()->id ))
+                            <div class="request-button">
+                                <button type="button" class="btn font-weight-bold button-design">作者にリクエストする</button>
+                            </div>
+                            <div class="request justify-content-center mt-3" id="request">
+                                <div class="request__area">
+                                    <div class="font-weight-bold text-center">
+                                        {{ $post->user->name}}さんへのリクエスト
+                                    </div>
                                 </div>
+                                @if ($errors->has('title'))
+                                    <div class="alert alert-danger mt-3">
+                                        <ul class="mb-0">
+                                            @foreach ($errors->get('title') as $error)
+                                                <li>{{ $error }}</li>
+                                            @endforeach
+                                        </ul>
+                                    </div>
+                                @endif
+                                <form method="POST" action="{{route('request_messages.store')}}">
+                                    @csrf
+                                    <input type="hidden" name="from_user_id"  value="{{ Auth::user()->id }}">
+                                    <input type="hidden" name="to_user_id"  value="{{ $post->user->id}}">
+                                    <input type="hidden" name="post_id"  value="{{ $post->id }}">
+                                    <div class="request__submit-area mt-3">
+                                        <input type="text" name="title" class="form-control" placeholder="タイトルを入力">
+                                        @if ($errors->has('body'))
+                                            <div class="alert alert-danger mt-3">
+                                                <ul class="mb-0">
+                                                    @foreach ($errors->get('body') as $error)
+                                                        <li>{{ $error }}</li>
+                                                    @endforeach
+                                                </ul>
+                                            </div>
+                                        @endif
+                                        <textarea name="body" class="form-control request__textarea mt-2" placeholder="描いてほしいテーマやキャラクターの特徴を伝えましょう。" aria-label="With textarea"></textarea>
+                                        <button type="input-group-prepend button submit" class="btn btn-outline-primary request__button">リクエストを送る</button>
+                                    </div>
+                                </form>
+                            </div>
                             @endif
-                            <form method="POST" action="{{route('request_messages.store')}}">
-                                @csrf
-                                <input type="hidden" name="from_user_id"  value="{{ Auth::user()->id }}">
-                                <input type="hidden" name="to_user_id"  value="{{ $post->user->id}}">
-                                <input type="hidden" name="post_id"  value="{{ $post->id }}">
-                                <div class="request__submit-area mt-3">
-                                    <input type="text" name="title" class="form-control" placeholder="タイトルを入力">
-                                    @if ($errors->has('body'))
-                                        <div class="alert alert-danger mt-3">
-                                            <ul class="mb-0">
-                                                @foreach ($errors->get('body') as $error)
-                                                    <li>{{ $error }}</li>
-                                                @endforeach
-                                            </ul>
-                                        </div>
-                                    @endif
-                                    <textarea name="body" class="form-control request__textarea mt-2" placeholder="描いてほしいテーマやキャラクターの特徴を伝えましょう。" aria-label="With textarea"></textarea>
-                                    <button type="input-group-prepend button submit" class="btn btn-outline-primary request__button">リクエストを送る</button>
-                                </div>
-                            </form>
-                        </div>
-                        @endif
-                    @endauth
+                        @endauth
+                    </div>
                 </div>
             </div>
         </div>


### PR DESCRIPTION
# What
投稿詳細ページのユーザー名と投稿の説明文のレイアウトを変更する。
- 元々spanタグを用いてユーザー名と説明文をインライン要素としていたがdivタグに変更し、display:flex;で横並びの要素に変更した。
- 詳細ページはbootstrapだけで作成していたがcssを当てた。

# Why
投稿詳細ページの説明文が改行した際に、次の行の開始位置に違和感があったため。